### PR TITLE
pitop.oled -> pitop.miniscreen.oled

### DIFF
--- a/src/components/Menu.py
+++ b/src/components/Menu.py
@@ -3,10 +3,10 @@ from components.helpers import MenuHelper
 from pitop.utils.sys_info import is_pi
 from pitop.utils.logger import PTLogger
 
-from pitop.oled import get_device_instance, reset_device_instance
+from pitop.miniscreen.oled import get_device_instance, reset_device_instance
 
 if is_pi():
-    from pitop.oled import PTOLEDDisplay
+    from pitop.miniscreen.oled import PTOLEDDisplay
 
 
 class Menu:

--- a/src/components/MenuManager.py
+++ b/src/components/MenuManager.py
@@ -3,7 +3,7 @@ from pitop.utils.sys_info import is_pi
 from subprocess import call
 from os import path, listdir
 
-from pitop.oled import get_device_instance, device_reserved
+from pitop.miniscreen.oled import get_device_instance, device_reserved
 from components.Menu import Menu
 from components.ButtonPress import ButtonPress
 from components.helpers.SubscriberClient import SubscriberClient

--- a/src/components/helpers/MenuHelper.py
+++ b/src/components/helpers/MenuHelper.py
@@ -1,4 +1,4 @@
-from pitop.oled import get_device_instance
+from pitop.miniscreen.oled import get_device_instance
 from components.Page import MenuPage
 from components.widgets.sys_info import (
     batt_level,

--- a/src/components/widgets/common/image_component.py
+++ b/src/components/widgets/common/image_component.py
@@ -1,7 +1,7 @@
 from pitop.utils.logger import PTLogger
 from PIL import Image
 from os.path import isfile
-from pitop.oled import get_device_instance
+from pitop.miniscreen.oled import get_device_instance
 
 
 def _create_bitmap_to_render(image, width, height):

--- a/src/pt-sys-oled
+++ b/src/pt-sys-oled
@@ -23,7 +23,7 @@ from pitop.utils.sys_info import is_pi
 from pitop.utils.logger import PTLogger
 from pitop.utils.command_runner import run_command
 from pitop.utils.common_names import DeviceName
-from pitop.oled import PTOLEDDisplay, get_device_instance
+from pitop.miniscreen.oled import PTOLEDDisplay, get_device_instance
 
 from components.widgets.common.functions import get_image_file
 
@@ -165,7 +165,7 @@ if __name__ == "__main__":
 
             # If device is not found, exit normally to avoid restarting the service repeatedly
             if device_found:
-                from pitop.oled import PTOLEDDisplay
+                from pitop.miniscreen.oled import PTOLEDDisplay
                 from components.MenuManager import MenuManager
 
                 oled = PTOLEDDisplay()


### PR DESCRIPTION
Required to work with pi-top SDK format change: https://github.com/pi-top/pi-top-Python-SDK/pull/75