### PR TITLE
Use environment variable for non-'exclusive mode'

### DIFF
--- a/debian/pt-sys-oled.service
+++ b/debian/pt-sys-oled.service
@@ -9,6 +9,7 @@ StartLimitBurst=5
 [Service]
 Type=simple
 Restart=on-failure
+Environment="PT_SDK_MINISCREEN_SYSTEM=1"
 Environment="PYTHONUNBUFFERED=1"
 Environment="PYTHONDONTWRITEBYTECODE=1"
 ExecStart=/usr/lib/pt-sys-oled/pt-sys-oled

--- a/src/components/MenuManager.py
+++ b/src/components/MenuManager.py
@@ -26,7 +26,7 @@ class MenuManager:
 
         self.current_menu = None
 
-        self.__buttons = Buttons(_exclusive_mode=False)
+        self.__buttons = Buttons()
 
         self.__buttons.up.when_pressed = lambda: self.__add_button_press_to_stack(
             ButtonPress(ButtonPress.ButtonType.UP))

--- a/src/pt-sys-oled
+++ b/src/pt-sys-oled
@@ -75,7 +75,7 @@ def main():
         if should_run():
             device_found = False
             try:
-                oled = OLED(_exclusive_mode=False)
+                oled = OLED()
                 device_found = True
             except DeviceNotFoundError as e:
                 PTLogger.error(f"Error getting device: {str(e)}")


### PR DESCRIPTION
Relates to https://github.com/pi-top/pi-top-Python-SDK/pull/196