### PR TITLE
Handle page size changes due to title bar on parent menu

### DIFF
--- a/pt_miniscreen/app.py
+++ b/pt_miniscreen/app.py
@@ -167,7 +167,7 @@ class App:
     def display_current_menu_image(self):
         logger.debug("Updating scroll position and displaying current menus' image...")
         self.menu_manager.update_current_menu_scroll_position()
-        self.display(self.menu_manager.current_menu.image)
+        self.display(self.menu_manager.image)
 
     def _main(self):
         # Ignore PIL debug messages -

--- a/pt_miniscreen/app.py
+++ b/pt_miniscreen/app.py
@@ -203,7 +203,10 @@ class App:
                     else:
                         interval = Speeds.SCROLL.value
                 else:
-                    interval = self.menu_manager.current_menu_page.interval
+                    interval = min(
+                        self.menu_manager.current_menu_page.interval,
+                        self.menu_manager.title_bar.interval,
+                    )
 
             logger.debug("Waiting until timeout or until page has changed...")
             self.menu_manager.wait_until_timeout_or_should_redraw_event(interval)

--- a/pt_miniscreen/config/classes/menu.py
+++ b/pt_miniscreen/config/classes/menu.py
@@ -4,7 +4,7 @@ from typing import Dict, Optional, Type
 from ...menu import Menu
 from .menu_edge_behaviour import MenuEdgeBehaviour
 from .page import PageConfig
-from .title_bar import TitleBarConfig
+from .title_bar import TitleBarBehaviour
 
 
 @dataclass
@@ -14,4 +14,4 @@ class MenuConfig:
     parent_goes_to_first_page: bool = True
     top_edge: MenuEdgeBehaviour = MenuEdgeBehaviour.NONE
     bottom_edge: MenuEdgeBehaviour = MenuEdgeBehaviour.NONE
-    title_bar: Optional[TitleBarConfig] = None
+    title_bar: Optional[TitleBarBehaviour] = None

--- a/pt_miniscreen/config/classes/menu_app.py
+++ b/pt_miniscreen/config/classes/menu_app.py
@@ -1,9 +1,11 @@
 from dataclasses import dataclass, field
-from typing import Dict
+from typing import Dict, Optional
 
 from .menu import MenuConfig
+from .title_bar import TitleBarConfig
 
 
 @dataclass
 class MenuAppConfig:
     children: Dict[str, MenuConfig] = field(default_factory=dict)
+    title_bar: Optional[TitleBarConfig] = None

--- a/pt_miniscreen/config/classes/title_bar.py
+++ b/pt_miniscreen/config/classes/title_bar.py
@@ -1,10 +1,18 @@
 from dataclasses import dataclass
-from typing import Type
+from typing import Optional, Type
 
 from ...pages.base import Page as PageBase
+
+
+@dataclass(eq=True)
+class TitleBarBehaviour:
+    text: Optional[str] = ""
+    visible: Optional[bool] = True
+    append_title: Optional[bool] = False
+    height: Optional[int] = None
 
 
 @dataclass
 class TitleBarConfig:
     page_cls: Type[PageBase]
-    height: int
+    props: TitleBarBehaviour

--- a/pt_miniscreen/config/classes/title_bar.py
+++ b/pt_miniscreen/config/classes/title_bar.py
@@ -15,4 +15,4 @@ class TitleBarBehaviour:
 @dataclass
 class TitleBarConfig:
     page_cls: Type[PageBase]
-    props: TitleBarBehaviour
+    behaviour: TitleBarBehaviour

--- a/pt_miniscreen/config/config.py
+++ b/pt_miniscreen/config/config.py
@@ -1,20 +1,23 @@
 from ..menu import Menu
-from ..pages import hud, settings, settings_connection
+from ..pages import hud, overlay, settings, settings_connection
 from .classes.menu import MenuConfig
 from .classes.menu_app import MenuAppConfig
 from .classes.menu_edge_behaviour import MenuEdgeBehaviour
 from .classes.page import PageConfig
-
-# from ..pages import overlay
-# from .classes.title_bar import TitleBarConfig
+from .classes.title_bar import TitleBarBehaviour, TitleBarConfig
 
 menu_app_config = MenuAppConfig(
+    title_bar=TitleBarConfig(
+        page_cls=overlay.title_bar.Page,
+        props=TitleBarBehaviour(height=19),
+    ),
     children=dict(
         [
             (
                 "hud",
                 MenuConfig(
                     menu_cls=Menu,
+                    title_bar=TitleBarBehaviour(visible=False),
                     top_edge=MenuEdgeBehaviour.NONE,
                     bottom_edge=MenuEdgeBehaviour.NONE,
                     children=dict(
@@ -35,9 +38,10 @@ menu_app_config = MenuAppConfig(
                     menu_cls=Menu,
                     top_edge=MenuEdgeBehaviour.NONE,
                     bottom_edge=MenuEdgeBehaviour.NONE,
-                    # title_bar=TitleBarConfig(
-                    #     page_cls=overlay.title_bar.Page, height=19
-                    # ),
+                    title_bar=TitleBarBehaviour(
+                        visible=True,
+                        text="Settings",
+                    ),
                     children=dict(
                         [
                             (
@@ -52,9 +56,10 @@ menu_app_config = MenuAppConfig(
                                                     menu_cls=Menu,
                                                     top_edge=MenuEdgeBehaviour.NONE,
                                                     bottom_edge=MenuEdgeBehaviour.NONE,
-                                                    # title_bar=TitleBarConfig(
-                                                    #     page_cls=overlay.title_bar.Page, height=19
-                                                    # ),
+                                                    title_bar=TitleBarBehaviour(
+                                                        text="Connection",
+                                                        append_title=True,
+                                                    ),
                                                     children=dict(
                                                         [
                                                             (
@@ -116,5 +121,5 @@ menu_app_config = MenuAppConfig(
                 ),
             ),
         ]
-    )
+    ),
 )

--- a/pt_miniscreen/config/config.py
+++ b/pt_miniscreen/config/config.py
@@ -9,7 +9,7 @@ from .classes.title_bar import TitleBarBehaviour, TitleBarConfig
 menu_app_config = MenuAppConfig(
     title_bar=TitleBarConfig(
         page_cls=overlay.title_bar.Page,
-        props=TitleBarBehaviour(height=19),
+        behaviour=TitleBarBehaviour(height=19),
     ),
     children=dict(
         [

--- a/pt_miniscreen/config/manager.py
+++ b/pt_miniscreen/config/manager.py
@@ -67,8 +67,8 @@ class MenuConfigManager:
         if menu_app_config.title_bar:
             return menu_app_config.title_bar.page_cls(
                 interval=Speeds.DYNAMIC_PAGE_REDRAW.value,
-                size=(size[0], menu_app_config.title_bar.props.height),
+                size=(size[0], menu_app_config.title_bar.behaviour.height),
                 mode=mode,
                 config=None,
-                title_bar_behaviour=menu_app_config.title_bar.props,
+                title_bar_behaviour=menu_app_config.title_bar.behaviour,
             )

--- a/pt_miniscreen/config/manager.py
+++ b/pt_miniscreen/config/manager.py
@@ -64,11 +64,13 @@ class MenuConfigManager:
 
     @staticmethod
     def get_title_bar(size, mode):
-        if menu_app_config.title_bar:
-            return menu_app_config.title_bar.page_cls(
-                interval=Speeds.DYNAMIC_PAGE_REDRAW.value,
-                size=(size[0], menu_app_config.title_bar.behaviour.height),
-                mode=mode,
-                config=None,
-                title_bar_behaviour=menu_app_config.title_bar.behaviour,
-            )
+        if not menu_app_config.title_bar:
+            return
+
+        return menu_app_config.title_bar.page_cls(
+            interval=Speeds.DYNAMIC_PAGE_REDRAW.value,
+            size=(size[0], menu_app_config.title_bar.behaviour.height),
+            mode=mode,
+            config=None,
+            title_bar_behaviour=menu_app_config.title_bar.behaviour,
+        )

--- a/pt_miniscreen/config/manager.py
+++ b/pt_miniscreen/config/manager.py
@@ -61,3 +61,14 @@ class MenuConfigManager:
         keys = [key for key in menus if (lookup in key and lookup != key)]
 
         return len(keys) > 0
+
+    @staticmethod
+    def get_title_bar(size, mode):
+        if menu_app_config.title_bar:
+            return menu_app_config.title_bar.page_cls(
+                interval=Speeds.DYNAMIC_PAGE_REDRAW.value,
+                size=(size[0], menu_app_config.title_bar.props.height),
+                mode=mode,
+                config=None,
+                title_bar_behaviour=menu_app_config.title_bar.props,
+            )

--- a/pt_miniscreen/event.py
+++ b/pt_miniscreen/event.py
@@ -20,6 +20,7 @@ class AppEvents(Enum):
     UP_BUTTON_PRESS = auto()  # callable
     DOWN_BUTTON_PRESS = auto()  # callable
     BUTTON_ACTION_START = auto()
+    TITLE_BAR_HEIGHT_CHANGED = auto()  # int
 
 
 subscribers: Dict[AppEvents, List] = dict()

--- a/pt_miniscreen/hotspots/base.py
+++ b/pt_miniscreen/hotspots/base.py
@@ -18,6 +18,22 @@ class Hotspot:
         self.width = size[0]
         self.height = size[1]
 
+    @property
+    def width(self):
+        return self.size[0]
+
+    @width.setter
+    def width(self, value):
+        self.size = (value, self.height)
+
+    @property
+    def height(self):
+        return self.size[1]
+
+    @height.setter
+    def height(self, value):
+        self.size = (self.width, value)
+
     def should_redraw(self):
         if not self.draw_white and not self.draw_black:
             return False

--- a/pt_miniscreen/hotspots/marquee_text_hotspot.py
+++ b/pt_miniscreen/hotspots/marquee_text_hotspot.py
@@ -5,6 +5,7 @@ import PIL.ImageFont
 from pitop.miniscreen.oled.assistant import MiniscreenAssistant
 
 from ..scroll import marquee_generator, pause_every
+from ..state import Speeds
 from .base import Hotspot as HotspotBase
 
 logger = logging.getLogger(__name__)
@@ -14,7 +15,9 @@ class Hotspot(HotspotBase):
     def __init__(self, interval, size, mode, text, font=None, font_size=20):
         super().__init__(interval, size, mode)
         self.assistant = MiniscreenAssistant(self.mode, self.size)
+        self.text_image = PIL.Image.new(self.mode, self.size, color="black")
 
+        self._interval = interval
         self.font_size = font_size
 
         if font is None:
@@ -67,3 +70,20 @@ class Hotspot(HotspotBase):
             ),
             sleep_for=7,
         )
+
+    @property
+    def needs_scrolling(self):
+        try:
+            return self.width <= self.text_image.width
+        except Exception:
+            return False
+
+    @property
+    def interval(self):
+        if not self.needs_scrolling:
+            return Speeds.DYNAMIC_PAGE_REDRAW.value
+        return self._interval
+
+    @interval.setter
+    def interval(self, value):
+        self._interval = value

--- a/pt_miniscreen/menu_manager.py
+++ b/pt_miniscreen/menu_manager.py
@@ -66,7 +66,7 @@ class MenuManager:
     @current_menu_id.setter
     def current_menu_id(self, menu_id):
         self._current_menu_id = menu_id
-        self.title_bar.update(self.current_menu.title_bar)
+        self.title_bar.behaviour = self.current_menu.title_bar
         self.should_redraw_event.set()
 
     @property

--- a/pt_miniscreen/menu_manager.py
+++ b/pt_miniscreen/menu_manager.py
@@ -1,6 +1,8 @@
 import logging
 from threading import Event
 
+import PIL.Image
+
 from .config import MenuConfigManager
 from .event import AppEvents, post_event, subscribe
 
@@ -9,12 +11,20 @@ logger = logging.getLogger(__name__)
 
 class MenuManager:
     def __init__(self, size, mode):
+        self.size = size
+        self.mode = mode
         self.is_skipping = False
 
-        self.menus = MenuConfigManager.get_menus_dict(size, mode)
+        self.title_bar = MenuConfigManager.get_title_bar(size, mode)
+        self.menus = MenuConfigManager.get_menus_dict((size[0], size[1]), mode)
+        self.should_redraw_event = Event()
+
+        def update_current_menu_height(_):
+            self.current_menu.window_height = self.size[1] - self.title_bar.height
+
+        subscribe(AppEvents.TITLE_BAR_HEIGHT_CHANGED, update_current_menu_height)
 
         self.current_menu_id = list(self.menus.keys())[0]
-        self.should_redraw_event = Event()
 
         subscribe(
             AppEvents.UP_BUTTON_PRESS,
@@ -36,6 +46,28 @@ class MenuManager:
             AppEvents.CANCEL_BUTTON_PRESS,
             lambda callback_handler: callback_handler(self._handle_cancel_btn),
         )
+
+    @property
+    def image(self):
+        im = PIL.Image.new(self.mode, self.size)
+        title_bar_height = 0
+        if self.title_bar is not None and self.title_bar.should_draw():
+            title_bar_height = self.title_bar.height
+            title_bar_im = PIL.Image.new(self.mode, (self.size[0], title_bar_height))
+            self.title_bar.render(title_bar_im)
+            im.paste(title_bar_im, (0, 0) + (self.size[0], title_bar_height))
+        im.paste(self.current_menu.image, (0, title_bar_height) + self.size)
+        return im
+
+    @property
+    def current_menu_id(self):
+        return self._current_menu_id
+
+    @current_menu_id.setter
+    def current_menu_id(self, menu_id):
+        self._current_menu_id = menu_id
+        self.title_bar.update(self.current_menu.title_bar)
+        self.should_redraw_event.set()
 
     @property
     def current_menu(self):
@@ -69,6 +101,7 @@ class MenuManager:
         self.should_redraw_event.set()
 
     def _go_to_parent_menu(self):
+
         self.current_menu_id = MenuConfigManager.get_parent_menu_id(
             self.current_menu_id
         )

--- a/pt_miniscreen/pages/base.py
+++ b/pt_miniscreen/pages/base.py
@@ -3,22 +3,19 @@ from ..config import ConfigFactory
 
 class Page:
     def __init__(self, interval, size, mode, config):
-        self.size = size
+        self._size = size
         self.mode = mode
 
         self.invert = False
-        self.width = size[0]
-        self.height = size[1]
         self.visible = True
         self.font_size = 14
         self.wrap = True
 
         golden_ratio = (1 + 5 ** 0.5) / 2
-        self.long_section_width = int(size[0] / golden_ratio)
-        self.short_section_width = size[0] - self.long_section_width
+        self.long_section_width = int(self.width / golden_ratio)
+        self.short_section_width = self.width - self.long_section_width
 
         config_factory = ConfigFactory(size, mode, interval)
-
         self.child_menu = dict()
         if config and config.child_menu:
             for menu_name, menu_config in config.child_menu.items():
@@ -26,8 +23,40 @@ class Page:
 
         self.hotspots = dict()
 
+    @property
+    def size(self):
+        return self._size
+
+    @size.setter
+    def size(self, value):
+        self._size = value
+        # Resize hotspots
+        self.setup_hotspots()
+        # Resize childs
+        for _, menu in self.child_menu.items():
+            menu.size = self.size
+
+    @property
+    def width(self):
+        return self.size[0]
+
+    @width.setter
+    def width(self, value):
+        self.size = (value, self.height)
+
+    @property
+    def height(self):
+        return self.size[1]
+
+    @height.setter
+    def height(self, value):
+        self.size = (self.width, value)
+
     def on_select_press(self):
         # Only invoked if there is no child menu in config
+        pass
+
+    def setup_hotspots(self):
         pass
 
     def render(self, image):
@@ -38,9 +67,8 @@ class Page:
     @property
     def interval(self):
         _interval = 1
-        for position, hotspot_list in self.hotspots.items():
+        for _, hotspot_list in self.hotspots.items():
             for hotspot in hotspot_list:
                 if hotspot.interval < _interval:
                     _interval = hotspot.interval
-
         return _interval

--- a/pt_miniscreen/pages/base.py
+++ b/pt_miniscreen/pages/base.py
@@ -1,4 +1,5 @@
 from ..config import ConfigFactory
+from ..state import Speeds
 
 
 class Page:
@@ -66,7 +67,7 @@ class Page:
 
     @property
     def interval(self):
-        _interval = 1
+        _interval = Speeds.DYNAMIC_PAGE_REDRAW.value
         for _, hotspot_list in self.hotspots.items():
             for hotspot in hotspot_list:
                 if hotspot.interval < _interval:

--- a/pt_miniscreen/pages/hud/battery.py
+++ b/pt_miniscreen/pages/hud/battery.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Dict  # , List, Tuple
 
 from pitop.battery import Battery
 
@@ -10,6 +9,12 @@ from ...utils import get_image_file_path
 from ..base import Page as PageBase
 
 logger = logging.getLogger(__name__)
+
+
+RECTANGLE_HOTSPOT_SIZE = (37, 14)
+BATTERY_LEFT_MARGIN = 15
+CAPACITY_RECTANGLE_LEFT_OFFSET = 4
+CAPACITY_RECTANGLE_LEFT_MARGIN = BATTERY_LEFT_MARGIN + CAPACITY_RECTANGLE_LEFT_OFFSET
 
 
 class Page(PageBase):
@@ -24,37 +29,39 @@ class Page(PageBase):
         except Exception:
             pass
 
+        self.setup_hotspots()
+
+    def setup_hotspots(self):
         self.text_hotspot = TextHotspot(
-            interval=interval,
-            mode=mode,
-            size=(self.long_section_width, size[1]),
+            interval=self.interval,
+            mode=self.mode,
+            size=(self.long_section_width, self.height),
             text=f"{self.capacity}%",
             font_size=19,
-            xy=(self.short_section_width, size[1] / 2),
+            xy=(self.short_section_width, self.height / 2),
         )
 
         self.battery_base_hotspot = ImageHotspot(
-            interval=interval,
-            mode=mode,
-            size=(self.short_section_width, size[1]),
+            interval=self.interval,
+            mode=self.mode,
+            size=(self.short_section_width, self.height),
             image_path=None,
         )
 
         self.rectangle_hotspot = RectangleHotspot(
-            interval=interval, mode=mode, size=(37, 14), bounding_box=(0, 0, 0, 0)
+            interval=self.interval,
+            mode=self.mode,
+            size=RECTANGLE_HOTSPOT_SIZE,
+            bounding_box=(0, 0, 0, 0),
         )
 
-        battery_left_margin = 15
-        capacity_rectangle_left_offset = 4
-        capacity_rectangle_left_margin = (
-            battery_left_margin + capacity_rectangle_left_offset
+        capacity_rectangle_top_margin = int(
+            (self.height - RECTANGLE_HOTSPOT_SIZE[1]) / 2
         )
-        capacity_rectangle_top_margin = 25
 
-        # self.hotspots: Dict[Tuple, List[Hotspot]] = {
-        self.hotspots: Dict = {
-            (battery_left_margin, 0): [self.battery_base_hotspot],
-            (capacity_rectangle_left_margin, capacity_rectangle_top_margin): [
+        self.hotspots = {
+            (BATTERY_LEFT_MARGIN, 0): [self.battery_base_hotspot],
+            (CAPACITY_RECTANGLE_LEFT_MARGIN, capacity_rectangle_top_margin): [
                 self.rectangle_hotspot
             ],
             (self.short_section_width, 0): [self.text_hotspot],

--- a/pt_miniscreen/pages/hud/wifi.py
+++ b/pt_miniscreen/pages/hud/wifi.py
@@ -11,19 +11,20 @@ from ...hotspots.wifi_strength_hotspot import Hotspot as WifiStrengthHotspot
 from ...utils import get_image_file_path
 from ..base import Page as PageBase
 
-MARGIN_X_LEFT = 30
-MARGIN_X_RIGHT = 10
-COMMON_FIRST_LINE_Y = 10
-COMMON_SECOND_LINE_Y = COMMON_FIRST_LINE_Y + 16
-COMMON_THIRD_LINE_Y = COMMON_SECOND_LINE_Y + 16
-ICON_HEIGHT = 12
-ICON_X_POS = 10
-DEFAULT_FONT_SIZE = 12
-
 
 class Page(PageBase):
     def __init__(self, interval, size, mode, config):
         super().__init__(interval=interval, size=size, mode=mode, config=config)
+        MARGIN_X_LEFT = 30
+        MARGIN_X_RIGHT = 10
+        SCALE = self.height / 64.0
+        DELTA_Y = int(16 * SCALE)
+        COMMON_FIRST_LINE_Y = int(10 * SCALE)
+        COMMON_SECOND_LINE_Y = COMMON_FIRST_LINE_Y + DELTA_Y
+        COMMON_THIRD_LINE_Y = COMMON_SECOND_LINE_Y + DELTA_Y
+        ICON_HEIGHT = 12
+        ICON_X_POS = 10
+        DEFAULT_FONT_SIZE = 12
 
         self.hotspots: Dict = {
             (0, 0): [

--- a/pt_miniscreen/pages/overlay/title_bar.py
+++ b/pt_miniscreen/pages/overlay/title_bar.py
@@ -61,8 +61,9 @@ class Page(PageBase):
                         size=self.size,
                         text=self.behaviour.text,
                         font=asst.get_mono_font(
-                            size=self.font_size
-                        ),  # bold=True, TODO: provide support in SDK
+                            size=self.font_size,
+                            bold=True,
+                        ),
                         font_size=14,
                     )
                 ],

--- a/pt_miniscreen/pages/overlay/title_bar.py
+++ b/pt_miniscreen/pages/overlay/title_bar.py
@@ -53,20 +53,26 @@ class Page(PageBase):
 
         if self.height != 0:
             asst = MiniscreenAssistant(self.mode, self.size)
+            marquee_text_hotspot = MarqueeTextHotspot(
+                interval=Speeds.MARQUEE.value,
+                mode=self.mode,
+                size=self.size,
+                text=self.behaviour.text,
+                font=asst.get_mono_font(
+                    size=self.font_size,
+                    bold=True,
+                ),
+                font_size=14,
+            )
+            marquee_hotspot_x_pos = 0
+            if not marquee_text_hotspot.needs_scrolling:
+                # if no scroll is needed, center text in screen
+                marquee_hotspot_x_pos = int(
+                    (self.width - marquee_text_hotspot.text_image.width) / 2
+                )
+
             self.hotspots: Dict = {
-                (0, 0): [
-                    MarqueeTextHotspot(
-                        interval=Speeds.MARQUEE.value,
-                        mode=self.mode,
-                        size=self.size,
-                        text=self.behaviour.text,
-                        font=asst.get_mono_font(
-                            size=self.font_size,
-                            bold=True,
-                        ),
-                        font_size=14,
-                    )
-                ],
+                (marquee_hotspot_x_pos, 0): [marquee_text_hotspot],
                 (0, self.height - 1): [
                     RectangleHotspot(
                         interval=self.interval,

--- a/pt_miniscreen/pages/overlay/title_bar.py
+++ b/pt_miniscreen/pages/overlay/title_bar.py
@@ -3,39 +3,75 @@ from typing import Dict
 
 from pitop.miniscreen.oled.assistant import MiniscreenAssistant
 
+from pt_miniscreen.state import Speeds
+
+from ...event import AppEvents, post_event
+from ...hotspots.marquee_text_hotspot import Hotspot as MarqueeTextHotspot
 from ...hotspots.rectangle_hotspot import Hotspot as RectangleHotspot
-from ...hotspots.text_hotspot import Hotspot as TextHotspot
 from ..base import Page as PageBase
 
 logger = logging.getLogger(__name__)
 
 
 class Page(PageBase):
-    def __init__(self, interval, size, mode, config):
+    def __init__(self, interval, size, mode, config, title_bar_behaviour):
         super().__init__(interval, size, mode, config)
+        self.current_behaviour = title_bar_behaviour
+        self.update(title_bar_behaviour)
 
-        asst = MiniscreenAssistant(mode, size)
+    def should_draw(self):
+        return (
+            self.current_behaviour.height != 0
+            and self.current_behaviour.text != ""
+            and self.current_behaviour.visible is True
+        )
 
-        self.text = "Settings"
+    def update(self, title_bar_behaviour):
+        if self.current_behaviour == title_bar_behaviour or title_bar_behaviour is None:
+            return
 
-        self.hotspots: Dict = {
-            (0, 0): [
-                TextHotspot(
-                    interval=interval,
-                    mode=mode,
-                    size=size,
-                    text=self.text,
-                    font=asst.get_mono_font_path(bold=True),
-                    font_size=14,
-                    fill="white",
-                )
-            ],
-            (0, size[1] - 1): [
-                RectangleHotspot(
-                    interval=interval,
-                    mode=mode,
-                    size=(size[0], 1),
-                    bounding_box=(0, 0) + (size[0], 1),
-                )
-            ],
-        }
+        if title_bar_behaviour.append_title:
+            self.current_behaviour.text = (
+                f"{self.current_behaviour.text} / {title_bar_behaviour.text}"
+            )
+        else:
+            self.current_behaviour.text = title_bar_behaviour.text
+        self.current_behaviour.visible = title_bar_behaviour.visible
+        if title_bar_behaviour.height is not None:
+            self.current_behaviour.height = title_bar_behaviour.height
+
+        if title_bar_behaviour.visible is False or title_bar_behaviour.text == "":
+            self.height = 0
+        else:
+            self.height = (
+                title_bar_behaviour.height
+                if title_bar_behaviour.height
+                else self.current_behaviour.height
+            )
+
+        post_event(AppEvents.TITLE_BAR_HEIGHT_CHANGED, self.height)
+
+        if self.height != 0:
+            asst = MiniscreenAssistant(self.mode, self.size)
+            self.hotspots: Dict = {
+                (0, 0): [
+                    MarqueeTextHotspot(
+                        interval=Speeds.MARQUEE.value,
+                        mode=self.mode,
+                        size=self.size,
+                        text=self.current_behaviour.text,
+                        font=asst.get_mono_font(
+                            size=self.font_size
+                        ),  # bold=True, TODO: provide support in SDK
+                        font_size=14,
+                    )
+                ],
+                (0, self.height - 1): [
+                    RectangleHotspot(
+                        interval=self.interval,
+                        mode=self.mode,
+                        size=(self.width, 1),
+                        bounding_box=(0, 0) + (self.width, 1),
+                    )
+                ],
+            }

--- a/pt_miniscreen/pages/overlay/title_bar.py
+++ b/pt_miniscreen/pages/overlay/title_bar.py
@@ -16,38 +16,38 @@ logger = logging.getLogger(__name__)
 class Page(PageBase):
     def __init__(self, interval, size, mode, config, title_bar_behaviour):
         super().__init__(interval, size, mode, config)
-        self.current_behaviour = title_bar_behaviour
-        self.update(title_bar_behaviour)
+        self._behaviour = title_bar_behaviour
 
     def should_draw(self):
         return (
-            self.current_behaviour.height != 0
-            and self.current_behaviour.text != ""
-            and self.current_behaviour.visible is True
+            self.behaviour.height != 0
+            and self.behaviour.text != ""
+            and self.behaviour.visible is True
         )
 
-    def update(self, title_bar_behaviour):
-        if self.current_behaviour == title_bar_behaviour or title_bar_behaviour is None:
+    @property
+    def behaviour(self):
+        return self._behaviour
+
+    @behaviour.setter
+    def behaviour(self, title_bar_behaviour):
+        if self.behaviour == title_bar_behaviour or title_bar_behaviour is None:
             return
 
         if title_bar_behaviour.append_title:
-            self.current_behaviour.text = (
-                f"{self.current_behaviour.text} / {title_bar_behaviour.text}"
-            )
+            self.behaviour.text = f"{self.behaviour.text} / {title_bar_behaviour.text}"
         else:
-            self.current_behaviour.text = title_bar_behaviour.text
-        self.current_behaviour.visible = title_bar_behaviour.visible
-        if title_bar_behaviour.height is not None:
-            self.current_behaviour.height = title_bar_behaviour.height
+            self.behaviour.text = title_bar_behaviour.text
 
-        if title_bar_behaviour.visible is False or title_bar_behaviour.text == "":
+        self.behaviour.visible = title_bar_behaviour.visible
+        if title_bar_behaviour.height is not None:
+            self.behaviour.height = title_bar_behaviour.height
+
+        self.height = self.behaviour.height
+        if not title_bar_behaviour.visible or title_bar_behaviour.text == "":
             self.height = 0
-        else:
-            self.height = (
-                title_bar_behaviour.height
-                if title_bar_behaviour.height
-                else self.current_behaviour.height
-            )
+        elif title_bar_behaviour.height:
+            self.height = title_bar_behaviour.height
 
         post_event(AppEvents.TITLE_BAR_HEIGHT_CHANGED, self.height)
 
@@ -59,7 +59,7 @@ class Page(PageBase):
                         interval=Speeds.MARQUEE.value,
                         mode=self.mode,
                         size=self.size,
-                        text=self.current_behaviour.text,
+                        text=self.behaviour.text,
                         font=asst.get_mono_font(
                             size=self.font_size
                         ),  # bold=True, TODO: provide support in SDK

--- a/pt_miniscreen/pages/settings/connection.py
+++ b/pt_miniscreen/pages/settings/connection.py
@@ -9,22 +9,25 @@ from ..base import Page as PageBase
 class Page(PageBase):
     def __init__(self, interval, size, mode, config):
         super().__init__(interval=interval, size=size, mode=mode, config=config)
+        self.setup_hotspots()
+
+    def setup_hotspots(self):
         self.hotspots: Dict = {
             (0, 0): [
                 ImageHotspot(
-                    interval=interval,
-                    mode=mode,
+                    interval=self.interval,
+                    mode=self.mode,
                     # TODO: crop settings icon and re-position
                     # size=(self.short_section_width, size[1]),
-                    size=size,
+                    size=self.size,
                     image_path=get_image_file_path("menu/settings.gif"),
                 ),
             ],
             (int(self.width / 4), 0): [
                 TextHotspot(
-                    interval=interval,
-                    mode=mode,
-                    size=(self.width - int(self.width / 4), size[1]),
+                    interval=self.interval,
+                    mode=self.mode,
+                    size=(self.width - int(self.width / 4), self.height),
                     text="Connection",
                     font_size=14,
                 )

--- a/pt_miniscreen/pages/settings_connection/action.py
+++ b/pt_miniscreen/pages/settings_connection/action.py
@@ -13,10 +13,18 @@ from .action_state import ActionState
 
 class Page(PageBase):
     def __init__(
-        self, interval, size, mode, config, get_state_method, set_state_method, icon
+        self,
+        interval,
+        size,
+        mode,
+        config,
+        get_state_method,
+        set_state_method,
+        icon,
     ):
         super().__init__(interval=interval, size=size, mode=mode, config=config)
 
+        self.icon = icon
         self.get_state_method = get_state_method
         self.set_state_method = set_state_method
 
@@ -31,23 +39,26 @@ class Page(PageBase):
         else:
             self.action_state = ActionState.DISABLED
 
+        self.setup_hotspots()
+
+    def setup_hotspots(self):
         self.hotspots: Dict = {
-            (self.size[0] - 24, int((self.size[1] - 24) / 2)): [
-                self.status_icon_hotspot
-            ],
+            (self.width - 24, int((self.height - 24) / 2)): [self.status_icon_hotspot],
             (1, 0): [
                 ImageHotspot(
-                    interval=interval,
-                    mode=mode,
-                    size=(self.short_section_width, size[1]),
-                    image_path=get_image_file_path(f"settings/icons/status/{icon}.png"),
+                    interval=self.interval,
+                    mode=self.mode,
+                    size=(self.short_section_width, self.height),
+                    image_path=get_image_file_path(
+                        f"settings/icons/status/{self.icon}.png"
+                    ),
                 ),
             ],
             (int(self.width / 4), 0): [
                 TextHotspot(
-                    interval=interval,
-                    mode=mode,
-                    size=(self.width - int(self.width / 4), size[1]),
+                    interval=self.interval,
+                    mode=self.mode,
+                    size=(self.width - int(self.width / 4), self.height),
                     text="SSH",
                     font_size=14,
                 )

--- a/pt_miniscreen/state.py
+++ b/pt_miniscreen/state.py
@@ -30,7 +30,7 @@ class Speeds(Enum):
     SCROLL = 0.004
     SKIP = 0.001
     SCREENSAVER = 0.05
-    MARQUEE = 0.3
+    MARQUEE = 0.1
 
 
 class DisplayStateManager:

--- a/pt_miniscreen/viewport.py
+++ b/pt_miniscreen/viewport.py
@@ -34,20 +34,42 @@ class Viewport:
     """
 
     def __init__(self, display_size, window_size, mode):
-        self.size = display_size
-        self.width = self.size[0]
-        self.height = self.size[1]
-
-        self.window_width = window_size[0]
-        self.window_height = window_size[1]
-
+        self._size = display_size
+        self.window_size = window_size
         self.mode = mode
-
-        self.bounding_box = (0, 0, self.width - 1, self.height - 1)
 
         self._backing_image = Image.new(self.mode, self.size)
         self._position = (0, 0)
         self._hotspots: Dict[Any, List[Tuple]] = dict()
+
+    @property
+    def size(self):
+        return self._size
+
+    @size.setter
+    def size(self, value):
+        self._size = value
+        self.clear()
+
+    @property
+    def bounding_box(self):
+        return (0, 0, self.width - 1, self.height - 1)
+
+    @property
+    def width(self):
+        return self.size[0]
+
+    @property
+    def height(self):
+        return self.size[1]
+
+    @property
+    def window_width(self):
+        return self.window_size[0]
+
+    @property
+    def window_height(self):
+        return self.window_size[1]
 
     @property
     def image(self):
@@ -72,7 +94,6 @@ class Viewport:
                     hotspot.paste_into(self._backing_image, xy)
 
         im = self._backing_image.crop(box=self._crop_box())
-
         return im
 
     def clear(self):


### PR DESCRIPTION
### Summary

Handles page size changes due to title bar on parent menu:

- When navigating through menus, the title bar is updated based on the menu's title bar behaviour setting (`TitleBarBehaviour`), specified in `config.py`.
- If the title bar changes it's height in a particular menu, the `TITLE_BAR_HEIGHT_CHANGED` event is emitted.
- When the `TITLE_BAR_HEIGHT_CHANGED` event is emitted, `MenuManager` updates the current menu height. The menu will internally resize it's `viewport`, its `hotspots` and their positions.

Also:
- `MarqueeTextHotspot` reduces its `interval` if no scrolling is needed.
- Added `height` and `width` properties to `PageBase`, `Hotspot` and `Viewport` classes.
- Added `window_height` and `window_width` properties to `MenuBase` class.

#### Associated PRs

https://github.com/pi-top/pi-top-Python-SDK/pull/487