### PR TITLE
Update displayed image when hotspot is redrawn

### DIFF
--- a/pt_miniscreen/app.py
+++ b/pt_miniscreen/app.py
@@ -183,6 +183,7 @@ class App:
 
             logger.debug(f"Current state: {self.state_manager.state}")
 
+            interval = None
             if self.state_manager.state == DisplayState.SCREENSAVER:
                 self.show_screensaver_frame()
                 interval = Speeds.SCREENSAVER.value
@@ -193,8 +194,6 @@ class App:
                         interval = Speeds.SKIP.value
                     else:
                         interval = Speeds.SCROLL.value
-                else:
-                    interval = self.menu_manager.current_menu_page.interval
 
             logger.debug("Waiting until timeout or until page has changed...")
             self.menu_manager.wait_until_timeout_or_should_redraw_event(interval)

--- a/pt_miniscreen/app.py
+++ b/pt_miniscreen/app.py
@@ -190,10 +190,7 @@ class App:
             else:
                 self.display_current_menu_image()
                 if self.menu_manager.current_menu.needs_to_scroll:
-                    if self.menu_manager.is_skipping:
-                        interval = Speeds.SKIP.value
-                    else:
-                        interval = Speeds.SCROLL.value
+                    interval = Speeds.SCROLL.value
 
             logger.debug("Waiting until timeout or until page has changed...")
             self.menu_manager.wait_until_timeout_or_should_redraw_event(interval)

--- a/pt_miniscreen/app.py
+++ b/pt_miniscreen/app.py
@@ -2,6 +2,7 @@ import logging
 from os import environ
 from signal import SIGINT, SIGTERM, signal
 from threading import Event, Thread
+from time import sleep
 
 from pitop import Pitop
 
@@ -183,17 +184,13 @@ class App:
 
             logger.debug(f"Current state: {self.state_manager.state}")
 
-            interval = None
             if self.state_manager.state == DisplayState.SCREENSAVER:
                 self.show_screensaver_frame()
-                interval = Speeds.SCREENSAVER.value
+                sleep(Speeds.SCREENSAVER.value)
             else:
                 self.display_current_menu_image()
-                if self.menu_manager.current_menu.needs_to_scroll:
-                    interval = Speeds.SCROLL.value
-
-            logger.debug("Waiting until timeout or until page has changed...")
-            self.menu_manager.wait_until_timeout_or_should_redraw_event(interval)
+                logger.debug("Waiting until image to display has changed...")
+                self.menu_manager.wait_until_should_redraw()
 
             if self.state_manager.state == DisplayState.RUNNING_ACTION:
                 self.handle_action()

--- a/pt_miniscreen/event.py
+++ b/pt_miniscreen/event.py
@@ -21,7 +21,7 @@ class AppEvents(Enum):
     DOWN_BUTTON_PRESS = auto()  # callable
     BUTTON_ACTION_START = auto()
     TITLE_BAR_HEIGHT_SET = auto()  # int
-    REDRAWN_HOTSPOT = auto()
+    HOTSPOT_NEW_IMAGE = auto()
 
 
 subscribers: Dict[AppEvents, List] = dict()

--- a/pt_miniscreen/event.py
+++ b/pt_miniscreen/event.py
@@ -21,6 +21,7 @@ class AppEvents(Enum):
     DOWN_BUTTON_PRESS = auto()  # callable
     BUTTON_ACTION_START = auto()
     TITLE_BAR_HEIGHT_SET = auto()  # int
+    REDRAWN_HOTSPOT = auto()
 
 
 subscribers: Dict[AppEvents, List] = dict()

--- a/pt_miniscreen/event.py
+++ b/pt_miniscreen/event.py
@@ -21,7 +21,7 @@ class AppEvents(Enum):
     DOWN_BUTTON_PRESS = auto()  # callable
     BUTTON_ACTION_START = auto()
     TITLE_BAR_HEIGHT_SET = auto()  # int
-    HOTSPOT_NEW_IMAGE = auto()
+    ACTIVE_HOTSPOT_HAS_NEW_CACHED_IMAGE = auto()
 
 
 subscribers: Dict[AppEvents, List] = dict()

--- a/pt_miniscreen/hotspot_manager.py
+++ b/pt_miniscreen/hotspot_manager.py
@@ -134,7 +134,6 @@ class HotspotManager:
         hotspot = hotspot_instance.hotspot
         self.update_cached_images = True
         thread = Thread(target=run, args=(), daemon=True, name=hotspot)
-        thread.name = hotspot
         thread.start()
         self.image_caching_threads[hotspot] = thread
 

--- a/pt_miniscreen/hotspot_manager.py
+++ b/pt_miniscreen/hotspot_manager.py
@@ -128,7 +128,7 @@ class HotspotManager:
             while self.update_cached_images:
                 if self.active and self.is_hotspot_overlapping(hotspot_instance):
                     cache_new_image()
-                    post_event(AppEvents.HOTSPOT_NEW_IMAGE)
+                    post_event(AppEvents.ACTIVE_HOTSPOT_HAS_NEW_CACHED_IMAGE)
                 sleep(hotspot.interval)
 
         hotspot = hotspot_instance.hotspot

--- a/pt_miniscreen/hotspot_manager.py
+++ b/pt_miniscreen/hotspot_manager.py
@@ -6,6 +6,8 @@ from typing import Any, Dict, List, Tuple
 from PIL import Image
 from pitop.miniscreen.oled.assistant import MiniscreenAssistant
 
+from .event import AppEvents, post_event
+
 logger = logging.getLogger(__name__)
 
 
@@ -18,6 +20,7 @@ class HotspotManager:
         self.cached_images: Dict = dict()
         self.image_caching_threads: Dict = dict()
         self.update_cached_images = False
+        self.active = False
 
     @property
     def viewport_size(self):
@@ -123,6 +126,8 @@ class HotspotManager:
                     self.cached_images[
                         hotspot_instance.hotspot
                     ] = hotspot_instance.hotspot.image
+                    if self.active:
+                        post_event(AppEvents.REDRAWN_HOTSPOT, self)
 
                 sleep(hotspot_instance.hotspot.interval)
 

--- a/pt_miniscreen/hotspot_manager.py
+++ b/pt_miniscreen/hotspot_manager.py
@@ -128,7 +128,7 @@ class HotspotManager:
             while self.update_cached_images:
                 if self.active and self.is_hotspot_overlapping(hotspot_instance):
                     cache_new_image()
-                    post_event(AppEvents.REDRAWN_HOTSPOT)
+                    post_event(AppEvents.HOTSPOT_NEW_IMAGE)
                 sleep(hotspot.interval)
 
         hotspot = hotspot_instance.hotspot

--- a/pt_miniscreen/hotspot_manager.py
+++ b/pt_miniscreen/hotspot_manager.py
@@ -121,21 +121,22 @@ class HotspotManager:
 
     def _register_thread(self, hotspot_instance):
         def run():
+            def cache_new_image():
+                self.cached_images[hotspot] = hotspot.image
+
+            cache_new_image()
             while self.update_cached_images:
-                if self.is_hotspot_overlapping(hotspot_instance):
-                    self.cached_images[
-                        hotspot_instance.hotspot
-                    ] = hotspot_instance.hotspot.image
-                    if self.active:
-                        post_event(AppEvents.REDRAWN_HOTSPOT, self)
+                if self.active and self.is_hotspot_overlapping(hotspot_instance):
+                    cache_new_image()
+                    post_event(AppEvents.REDRAWN_HOTSPOT)
+                sleep(hotspot.interval)
 
-                sleep(hotspot_instance.hotspot.interval)
-
+        hotspot = hotspot_instance.hotspot
         self.update_cached_images = True
         thread = Thread(target=run, args=(), daemon=True)
-        thread.name = hotspot_instance.hotspot
+        thread.name = hotspot
         thread.start()
-        self.image_caching_threads[hotspot_instance.hotspot] = thread
+        self.image_caching_threads[hotspot] = thread
 
     def stop_threads(self):
         self.update_cached_images = False

--- a/pt_miniscreen/hotspot_manager.py
+++ b/pt_miniscreen/hotspot_manager.py
@@ -133,7 +133,7 @@ class HotspotManager:
 
         hotspot = hotspot_instance.hotspot
         self.update_cached_images = True
-        thread = Thread(target=run, args=(), daemon=True)
+        thread = Thread(target=run, args=(), daemon=True, name=hotspot)
         thread.name = hotspot
         thread.start()
         self.image_caching_threads[hotspot] = thread

--- a/pt_miniscreen/hotspots/marquee_text_hotspot.py
+++ b/pt_miniscreen/hotspots/marquee_text_hotspot.py
@@ -12,6 +12,8 @@ logger = logging.getLogger(__name__)
 
 
 class Hotspot(HotspotBase):
+    DELTA_PX = 2
+
     def __init__(self, interval, size, mode, text, font=None, font_size=20):
         super().__init__(interval, size, mode)
         self.assistant = MiniscreenAssistant(self.mode, self.size)
@@ -66,7 +68,7 @@ class Hotspot(HotspotBase):
             generator=marquee_generator(
                 min_value=0,
                 max_value=self.text_image.width - self.size[0],
-                resolution=2,
+                resolution=self.DELTA_PX,
             ),
             sleep_for=7,
         )

--- a/pt_miniscreen/menu.py
+++ b/pt_miniscreen/menu.py
@@ -203,3 +203,11 @@ class Menu:
             self.y_pos = value
         except StopIteration:
             pass
+
+    @property
+    def active(self):
+        return self.viewport.active
+
+    @active.setter
+    def active(self, value):
+        self.viewport.active = value

--- a/pt_miniscreen/menu_manager.py
+++ b/pt_miniscreen/menu_manager.py
@@ -54,7 +54,7 @@ class MenuManager:
         )
 
         subscribe(
-            AppEvents.REDRAWN_HOTSPOT,
+            AppEvents.HOTSPOT_NEW_IMAGE,
             lambda _: self.should_redraw_event.set(),
         )
 

--- a/pt_miniscreen/menu_manager.py
+++ b/pt_miniscreen/menu_manager.py
@@ -53,6 +53,11 @@ class MenuManager:
             lambda callback_handler: callback_handler(self._handle_cancel_btn),
         )
 
+        subscribe(
+            AppEvents.REDRAWN_HOTSPOT,
+            lambda _: self.should_redraw_event.set(),
+        )
+
     @property
     def image(self):
         im = PIL.Image.new(self.mode, self.size)
@@ -71,7 +76,10 @@ class MenuManager:
 
     @current_menu_id.setter
     def current_menu_id(self, menu_id):
+        if hasattr(self, "_current_menu_id"):
+            self.current_menu.active = False
         self._current_menu_id = menu_id
+        self.current_menu.active = True
         self.title_bar.behaviour = self.current_menu.title_bar
         logger.debug(
             f"current_menu_id.setter - title bar behaviour : {self.title_bar.behaviour}"

--- a/pt_miniscreen/menu_manager.py
+++ b/pt_miniscreen/menu_manager.py
@@ -55,7 +55,7 @@ class MenuManager:
         )
 
         subscribe(
-            AppEvents.HOTSPOT_NEW_IMAGE,
+            AppEvents.ACTIVE_HOTSPOT_HAS_NEW_CACHED_IMAGE,
             lambda _: self.should_redraw_event.set(),
         )
 

--- a/pt_miniscreen/menu_manager.py
+++ b/pt_miniscreen/menu_manager.py
@@ -1,10 +1,12 @@
 import logging
 from threading import Event
+from time import sleep
 
 import PIL.Image
 
 from .config import MenuConfigManager
 from .event import AppEvents, post_event, subscribe
+from .state import Speeds
 
 logger = logging.getLogger(__name__)
 
@@ -154,7 +156,11 @@ class MenuManager:
 
         self.current_menu.update_scroll_position()
 
-    def wait_until_timeout_or_should_redraw_event(self, timeout):
-        self.should_redraw_event.wait(timeout)
+    def wait_until_should_redraw(self):
+        if self.current_menu.needs_to_scroll:
+            sleep(Speeds.SCROLL.value)
+        else:
+            self.should_redraw_event.wait()
+
         if self.should_redraw_event.is_set():
             self.should_redraw_event.clear()

--- a/pt_miniscreen/menu_manager.py
+++ b/pt_miniscreen/menu_manager.py
@@ -13,7 +13,6 @@ class MenuManager:
     def __init__(self, size, mode):
         self.size = size
         self.mode = mode
-        self.is_skipping = False
 
         self.title_bar = MenuConfigManager.get_title_bar(size)
         self.menus = MenuConfigManager.get_menus_dict(size, mode)
@@ -151,7 +150,6 @@ class MenuManager:
 
     def update_current_menu_scroll_position(self):
         if not self.current_menu.needs_to_scroll:
-            self.is_skipping = False
             return
 
         self.current_menu.update_scroll_position()

--- a/pt_miniscreen/menu_manager.py
+++ b/pt_miniscreen/menu_manager.py
@@ -79,11 +79,11 @@ class MenuManager:
         if hasattr(self, "_current_menu_id"):
             self.current_menu.active = False
         self._current_menu_id = menu_id
-        self.current_menu.active = True
         self.title_bar.behaviour = self.current_menu.title_bar
         logger.debug(
             f"current_menu_id.setter - title bar behaviour : {self.title_bar.behaviour}"
         )
+        self.current_menu.active = True
         self.should_redraw_event.set()
 
     @property

--- a/pt_miniscreen/pages/overlay/title_bar.py
+++ b/pt_miniscreen/pages/overlay/title_bar.py
@@ -20,6 +20,7 @@ class TitleBar(HotspotManager):
         super().__init__(viewport_size, window_size, window_position)
         self.mode = "1"
         self._behaviour = title_bar_behaviour
+        self.active = True
 
     def should_draw(self):
         return (

--- a/pt_miniscreen/state.py
+++ b/pt_miniscreen/state.py
@@ -31,7 +31,7 @@ class Speeds(Enum):
     SKIP = 0.001
     SCREENSAVER = 0.05
     ACTION_STATE_UPDATE = 0.5
-    MARQUEE = 0.05
+    MARQUEE = 0.2
 
 
 class DisplayStateManager:

--- a/pt_miniscreen/state.py
+++ b/pt_miniscreen/state.py
@@ -28,7 +28,6 @@ class DisplayState(Enum):
 class Speeds(Enum):
     DYNAMIC_PAGE_REDRAW = 1
     SCROLL = 0.004
-    SKIP = 0.001
     SCREENSAVER = 0.05
     ACTION_STATE_UPDATE = 0.5
     MARQUEE = 0.2


### PR DESCRIPTION
Support hotspots with different refresh rates. All of the logic that deals with menu/hotspot intervals is now decoupled from `App` into `MenuManager`

Displayed image is updated when:
- The `ACTIVE_HOTSPOT_HAS_NEW_CACHED_IMAGE` event is emitted by a hotspot.
- When skipping/navigating through pages.

Also:
- Adds `active` property to `HotspotManager` to determine when if the hotspot should be updating its image.
- Hotspots don't generate images when it's `HotspotManager` isn't active.

TODO:
- Improve "busy wait" on thread that updates cached images - use events instead instead of sleeping.