### PR TITLE
Fix broken imports

### DIFF
--- a/pt_miniscreen/app.py
+++ b/pt_miniscreen/app.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from signal import SIGINT, SIGTERM, signal
 from threading import Event, Thread
 
-from imgcat import imgcat
 from pitop import Pitop
 
 from .event import AppEvent, post_event, subscribe
@@ -189,6 +188,8 @@ class App:
             self.display(self.current_tile_group.image)
             if environ.get("IMGCAT", "0") == "1":
                 print("")
+                from imgcat import imgcat
+
                 imgcat(self.current_tile_group.image)
 
             if environ.get("SAVE_CACHE", "0") == "1":

--- a/pt_miniscreen/hotspots/bootsplash.py
+++ b/pt_miniscreen/hotspots/bootsplash.py
@@ -3,8 +3,8 @@ from configparser import ConfigParser
 from os import path
 
 from ..event import AppEvent, post_event
-from ..hotspots.image import Hotspot as ImageHotspot
 from ..utils import get_image_file_path
+from .templates.image import Hotspot as ImageHotspot
 
 logger = logging.getLogger(__name__)
 

--- a/pt_miniscreen/hotspots/templates/image.py
+++ b/pt_miniscreen/hotspots/templates/image.py
@@ -2,8 +2,8 @@ import logging
 
 import PIL.Image
 
-from ..state import Speeds
-from .base import Hotspot as HotspotBase
+from ...state import Speeds
+from ..base import Hotspot as HotspotBase
 
 logger = logging.getLogger(__name__)
 

--- a/pt_miniscreen/hotspots/templates/marquee_dynamic_text.py
+++ b/pt_miniscreen/hotspots/templates/marquee_dynamic_text.py
@@ -3,8 +3,8 @@ from threading import Thread
 from time import sleep
 from typing import Callable
 
-from ..state import Speeds
-from ..types import Coordinate
+from ...state import Speeds
+from ...types import Coordinate
 from .marquee_text import Hotspot as MarqueeHotspotBase
 
 logger = logging.getLogger(__name__)

--- a/pt_miniscreen/hotspots/templates/marquee_text.py
+++ b/pt_miniscreen/hotspots/templates/marquee_text.py
@@ -4,10 +4,10 @@ from typing import Iterator
 from PIL import Image, ImageDraw
 from pitop.miniscreen.oled.assistant import MiniscreenAssistant
 
-from ..generators import carousel, pause_every
-from ..state import Speeds
-from ..types import Coordinate
-from .base import Hotspot as HotspotBase
+from ...generators import carousel, pause_every
+from ...state import Speeds
+from ...types import Coordinate
+from ..base import Hotspot as HotspotBase
 
 logger = logging.getLogger(__name__)
 

--- a/pt_miniscreen/hotspots/templates/rectangle.py
+++ b/pt_miniscreen/hotspots/templates/rectangle.py
@@ -1,7 +1,7 @@
 import PIL.Image
 
-from ..state import Speeds
-from .base import Hotspot as HotspotBase
+from ...state import Speeds
+from ..base import Hotspot as HotspotBase
 
 
 class Hotspot(HotspotBase):

--- a/pt_miniscreen/hotspots/templates/status_icon.py
+++ b/pt_miniscreen/hotspots/templates/status_icon.py
@@ -4,9 +4,9 @@ from math import ceil, floor
 import PIL.Image
 from pitop.miniscreen.oled.assistant import MiniscreenAssistant
 
-from ..pages.templates.action.state import ActionState
-from ..state import Speeds
-from .base import Hotspot as HotspotBase
+from ...pages.templates.action.state import ActionState
+from ...state import Speeds
+from ..base import Hotspot as HotspotBase
 
 logger = logging.getLogger(__name__)
 

--- a/pt_miniscreen/hotspots/templates/text.py
+++ b/pt_miniscreen/hotspots/templates/text.py
@@ -4,8 +4,8 @@ import PIL.ImageDraw
 import PIL.ImageFont
 from pitop.miniscreen.oled.assistant import MiniscreenAssistant
 
-from ..state import Speeds
-from .base import Hotspot as HotspotBase
+from ...state import Speeds
+from ..base import Hotspot as HotspotBase
 
 logger = logging.getLogger(__name__)
 

--- a/pt_miniscreen/pages/hud/battery.py
+++ b/pt_miniscreen/pages/hud/battery.py
@@ -3,9 +3,9 @@ import logging
 from pitop.battery import Battery
 
 from ...hotspots.base import HotspotInstance
-from ...hotspots.image import Hotspot as ImageHotspot
-from ...hotspots.rectangle import Hotspot as RectangleHotspot
-from ...hotspots.text import Hotspot as TextHotspot
+from ...hotspots.templates.image import Hotspot as ImageHotspot
+from ...hotspots.templates.rectangle import Hotspot as RectangleHotspot
+from ...hotspots.templates.text import Hotspot as TextHotspot
 from ...utils import get_image_file_path
 from ..base import Page as PageBase
 

--- a/pt_miniscreen/pages/hud/cpu.py
+++ b/pt_miniscreen/pages/hud/cpu.py
@@ -1,6 +1,6 @@
 from ...hotspots.base import HotspotInstance
 from ...hotspots.cpu_bars import Hotspot as CpuBarsHotspot
-from ...hotspots.image import Hotspot as ImageHotspot
+from ...hotspots.templates.image import Hotspot as ImageHotspot
 from ...utils import get_image_file_path
 from ..base import Page as PageBase
 

--- a/pt_miniscreen/pages/hud/network_page_base.py
+++ b/pt_miniscreen/pages/hud/network_page_base.py
@@ -2,8 +2,10 @@ from dataclasses import dataclass
 from typing import Any, Optional
 
 from ...hotspots.base import HotspotInstance
-from ...hotspots.image import Hotspot as ImageHotspot
-from ...hotspots.marquee_dynamic_text import Hotspot as MarqueeDynamicTextHotspot
+from ...hotspots.templates.image import Hotspot as ImageHotspot
+from ...hotspots.templates.marquee_dynamic_text import (
+    Hotspot as MarqueeDynamicTextHotspot,
+)
 from ...state import Speeds
 from ...types import Coordinate
 from ...utils import get_image_file_path

--- a/pt_miniscreen/pages/templates/action/page.py
+++ b/pt_miniscreen/pages/templates/action/page.py
@@ -3,9 +3,9 @@ from typing import Callable, Optional
 
 from ....event import AppEvent, subscribe
 from ....hotspots.base import HotspotInstance
-from ....hotspots.image import Hotspot as ImageHotspot
-from ....hotspots.marquee_text import Hotspot as MarqueeTextHotspot
-from ....hotspots.status_icon import Hotspot as StatusIconHotspot
+from ....hotspots.templates.image import Hotspot as ImageHotspot
+from ....hotspots.templates.marquee_text import Hotspot as MarqueeTextHotspot
+from ....hotspots.templates.status_icon import Hotspot as StatusIconHotspot
 from ....types import Coordinate
 from ....utils import get_image_file_path
 from ...base import Page as PageBase

--- a/pt_miniscreen/pages/templates/menu/page.py
+++ b/pt_miniscreen/pages/templates/menu/page.py
@@ -1,8 +1,8 @@
 from typing import Callable, Union
 
 from ....hotspots.base import HotspotInstance
-from ....hotspots.image import Hotspot as ImageHotspot
-from ....hotspots.text import Hotspot as TextHotspot
+from ....hotspots.templates.image import Hotspot as ImageHotspot
+from ....hotspots.templates.text import Hotspot as TextHotspot
 from ....types import Coordinate
 from ...base import Page as PageBase
 

--- a/pt_miniscreen/tiles/title_bar/settings.py
+++ b/pt_miniscreen/tiles/title_bar/settings.py
@@ -3,8 +3,8 @@ import logging
 from pitop.miniscreen.oled.assistant import MiniscreenAssistant
 
 from ...hotspots.base import HotspotInstance
-from ...hotspots.marquee_text import Hotspot as MarqueeTextHotspot
-from ...hotspots.rectangle import Hotspot as RectangleHotspot
+from ...hotspots.templates.marquee_text import Hotspot as MarqueeTextHotspot
+from ...hotspots.templates.rectangle import Hotspot as RectangleHotspot
 from ..base import Tile
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Fix imports so application runs:
- Updated imports from files that were moved to different folders.
- Import `imgcat`, used for debug purposes, only when used.