### PR TITLE
Create app StateManager before calling setup_events which uses it

### DIFF
--- a/pt_miniscreen/app.py
+++ b/pt_miniscreen/app.py
@@ -48,9 +48,9 @@ class App:
 
         self._add_tile_group_to_stack_from_cls(HUDTileGroup)
 
-        self.setup_events()
-
         self.state_manager = StateManager(self.miniscreen.contrast)
+
+        self.setup_events()
 
         logger.debug("Done initializing app")
 


### PR DESCRIPTION
I ran into this error on a fresh boot which caused my miniscreen menu to not respond to button presses:

```
-- Boot a55c6108508649229ce2a4ea7c963a84 --
Feb 03 12:35:46 pi-top systemd[1]: Started pi-top OLED system menu.
Feb 03 12:36:08 pi-top pt-miniscreen[1004]: Exception in thread Thread-4:
Feb 03 12:36:08 pi-top pt-miniscreen[1004]: Traceback (most recent call last):
Feb 03 12:36:08 pi-top pt-miniscreen[1004]:   File "/usr/lib/python3.9/threading.py", line 954, in _bootstrap_inner
Feb 03 12:36:08 pi-top pt-miniscreen[1004]:     self.run()
Feb 03 12:36:08 pi-top pt-miniscreen[1004]:   File "/usr/lib/python3.9/threading.py", line 892, in run
Feb 03 12:36:08 pi-top pt-miniscreen[1004]:     self._target(*self._args, **self._kwargs)
Feb 03 12:36:08 pi-top pt-miniscreen[1004]:   File "/usr/lib/python3/dist-packages/pitop/common/ptdm.py", line 457, in __thread_method
Feb 03 12:36:08 pi-top pt-miniscreen[1004]:     self.invoke_callback_func_if_exists(
Feb 03 12:36:08 pi-top pt-miniscreen[1004]:   File "/usr/lib/python3/dist-packages/pitop/common/ptdm.py", line 472, in invoke_callback_func_if_exists
Feb 03 12:36:08 pi-top pt-miniscreen[1004]:     func()
Feb 03 12:36:08 pi-top pt-miniscreen[1004]:   File "/usr/lib/python3/dist-packages/pitop/miniscreen/miniscreen.py", line 58, in <lambda>
Feb 03 12:36:08 pi-top pt-miniscreen[1004]:     Message.PUB_V3_BUTTON_SELECT_RELEASED: lambda: set_button_state(
Feb 03 12:36:08 pi-top pt-miniscreen[1004]:   File "/usr/lib/python3/dist-packages/pitop/miniscreen/miniscreen.py", line 34, in set_button_state
Feb 03 12:36:08 pi-top pt-miniscreen[1004]:     self.__ptdm_subscribe_client.invoke_callback_func_if_exists(
Feb 03 12:36:08 pi-top pt-miniscreen[1004]:   File "/usr/lib/python3/dist-packages/pitop/common/ptdm.py", line 472, in invoke_callback_func_if_exists
Feb 03 12:36:08 pi-top pt-miniscreen[1004]:     func()
Feb 03 12:36:08 pi-top pt-miniscreen[1004]:   File "/usr/lib/python3/dist-packages/pt_miniscreen/app.py", line 139, in <lambda>
Feb 03 12:36:08 pi-top pt-miniscreen[1004]:     self.miniscreen.select_button.when_released = lambda: handle_button_press(
Feb 03 12:36:08 pi-top pt-miniscreen[1004]:   File "/usr/lib/python3/dist-packages/pt_miniscreen/app.py", line 117, in handle_button_press
Feb 03 12:36:08 pi-top pt-miniscreen[1004]:     if not self.state_manager.buttons_should_be_handled():
Feb 03 12:36:08 pi-top pt-miniscreen[1004]: AttributeError: 'App' object has no attribute 'state_manager'
Feb 03 12:36:08 pi-top pt-miniscreen[1004]: Starting main loop...
```

It would appear that I pressed the select button before the app was fully initialised. Since `handle_button_press` uses the `self.state_manager.buttons_should_be_handled()`, it should be registered after the statemanager is created. `self.setup_events()` does the registration so that is moved down in the init method.