### PR TITLE
feat: add scrollbar to PaginatedTile

### DIFF
--- a/pt_miniscreen/generators/scroll.py
+++ b/pt_miniscreen/generators/scroll.py
@@ -10,7 +10,7 @@ def pause_every(pause_yield_interval, generator, no_of_pause_yields):
         except StopIteration:
             continue
 
-        if x % pause_yield_interval == 0:
+        if pause_yield_interval > 0 and x % pause_yield_interval == 0:
             # Pause
             logger.debug("Time to pause...")
             for _ in range(no_of_pause_yields):

--- a/pt_miniscreen/hotspots/scrollbar.py
+++ b/pt_miniscreen/hotspots/scrollbar.py
@@ -1,0 +1,29 @@
+import PIL.ImageDraw
+
+from .base import Hotspot as HotspotBase
+
+
+class Hotspot(HotspotBase):
+    def __init__(
+        self,
+        interval,
+        size,
+        bar_height,
+        bar_y_start=0,
+        bar_padding=3,
+    ):
+        super().__init__(interval=interval, size=size)
+        self.bar_height = bar_height
+        self.bar_padding = bar_padding
+        self.bar_y_pos = bar_y_start
+
+    def render(self, image):
+        PIL.ImageDraw.Draw(image).rectangle(
+            (
+                self.bar_padding,
+                self.bar_y_pos + self.bar_padding,
+                self.size[0] - self.bar_padding,
+                self.bar_y_pos + self.bar_height - self.bar_padding,
+            ),
+            fill="white",
+        )

--- a/pt_miniscreen/pages/hud/overview.py
+++ b/pt_miniscreen/pages/hud/overview.py
@@ -14,10 +14,11 @@ from ..base import Page as PageBase
 
 logger = logging.getLogger(__name__)
 
-FONT_SIZE = 19
+FONT_SIZE = 16
 ICON_HEIGHT = 22
 RECTANGLE_HOTSPOT_SIZE = (37, 14)
 BATTERY_LEFT_MARGIN = 15
+TEXT_LEFT_POSITION = 65
 CAPACITY_RECTANGLE_LEFT_OFFSET = 4
 CAPACITY_RECTANGLE_LEFT_MARGIN = BATTERY_LEFT_MARGIN + CAPACITY_RECTANGLE_LEFT_OFFSET
 
@@ -54,7 +55,7 @@ class Page(PageBase):
         )
 
         text_hotspot_pos = (
-            self.long_section_width,
+            TEXT_LEFT_POSITION,
             self.offset_pos_for_vertical_center(self.text_hotspot.text_size[1]),
         )
         battery_hotspot_pos = (

--- a/pt_miniscreen/pages/system/battery.py
+++ b/pt_miniscreen/pages/system/battery.py
@@ -11,10 +11,11 @@ from ..base import Page as PageBase
 
 logger = logging.getLogger(__name__)
 
-FONT_SIZE = 19
+FONT_SIZE = 16
 ICON_HEIGHT = 22
 RECTANGLE_HOTSPOT_SIZE = (37, 14)
-BATTERY_LEFT_MARGIN = 15
+BATTERY_LEFT_MARGIN = 10
+TEXT_LEFT_POSITION = 60
 CAPACITY_RECTANGLE_LEFT_OFFSET = 4
 CAPACITY_RECTANGLE_LEFT_MARGIN = BATTERY_LEFT_MARGIN + CAPACITY_RECTANGLE_LEFT_OFFSET
 
@@ -60,7 +61,7 @@ class Page(PageBase):
         )
 
         text_hotspot_pos = (
-            self.long_section_width,
+            TEXT_LEFT_POSITION,
             self.offset_pos_for_vertical_center(self.text_hotspot.text_size[1]),
         )
         battery_hotspot_pos = (

--- a/pt_miniscreen/pages/system/cpu.py
+++ b/pt_miniscreen/pages/system/cpu.py
@@ -5,6 +5,9 @@ from ...utils import get_image_file_path
 from ..base import Page as PageBase
 
 ICON_SIZE = 38
+ICON_LEFT_MARGIN = 5
+CPU_BARS_LEFT_MARGIN = 5
+CPU_BARS_TOTAL_WIDTH = 60
 
 
 class Page(PageBase):
@@ -21,17 +24,17 @@ class Page(PageBase):
                     size=(ICON_SIZE, ICON_SIZE),
                     image_path=get_image_file_path("sys_info/cpu.png"),
                 ),
-                (0, self.offset_pos_for_vertical_center(ICON_SIZE)),
+                (ICON_LEFT_MARGIN, self.offset_pos_for_vertical_center(ICON_SIZE)),
             ),
             HotspotInstance(
                 CpuBarsHotspot(
                     size=(
-                        self.long_section_width,
+                        CPU_BARS_TOTAL_WIDTH,
                         cpu_bar_hotspot_height,
                     ),
                 ),
                 (
-                    self.short_section_width,
+                    CPU_BARS_LEFT_MARGIN + ICON_SIZE + ICON_LEFT_MARGIN,
                     self.offset_pos_for_vertical_center(cpu_bar_hotspot_height),
                 ),
             ),

--- a/pt_miniscreen/pages/templates/menu/page.py
+++ b/pt_miniscreen/pages/templates/menu/page.py
@@ -24,8 +24,9 @@ class Page(PageBase):
 
     def reset(self) -> None:
         FONT_SIZE = 14
-        TEXT_LEFT_MARGIN = int(self.width * 0.3)
-        ICON_LEFT_MARGIN = int((TEXT_LEFT_MARGIN - self.image_size) / 2)
+        TEXT_LEFT = int(self.width * 0.375)
+        ICON_OFFSET = 3
+        ICON_LEFT = int((TEXT_LEFT - self.image_size) / 2) + ICON_OFFSET
 
         self.hotspot_instances = [
             HotspotInstance(
@@ -34,18 +35,18 @@ class Page(PageBase):
                     image_path=self.image_path,
                 ),
                 (
-                    ICON_LEFT_MARGIN,
+                    ICON_LEFT,
                     self.offset_pos_for_vertical_center(self.image_size),
                 ),
             ),
             HotspotInstance(
                 TextHotspot(
-                    size=(self.width - TEXT_LEFT_MARGIN, FONT_SIZE),
+                    size=(self.width - TEXT_LEFT, FONT_SIZE),
                     text=self.text,
                     font_size=FONT_SIZE,
                     anchor="lt",
                     xy=(0, 0),
                 ),
-                (TEXT_LEFT_MARGIN, self.offset_pos_for_vertical_center(FONT_SIZE)),
+                (TEXT_LEFT, self.offset_pos_for_vertical_center(FONT_SIZE)),
             ),
         ]

--- a/pt_miniscreen/tiles/menu/hud.py
+++ b/pt_miniscreen/tiles/menu/hud.py
@@ -8,12 +8,9 @@ class HUDMenuTile(MenuTile):
             size=size,
             pos=pos,
             pages=[
-                Page(size)
-                for Page in (
-                    OverviewPage,
-                    SystemMenuPage,
-                    NetworkMenuPage,
-                    SettingsMenuPage,
-                )
+                OverviewPage,
+                SystemMenuPage,
+                NetworkMenuPage,
+                SettingsMenuPage,
             ],
         )

--- a/pt_miniscreen/tiles/menu/network.py
+++ b/pt_miniscreen/tiles/menu/network.py
@@ -8,12 +8,9 @@ class NetworkMenuTile(MenuTile):
             size=size,
             pos=pos,
             pages=[
-                Page(size)
-                for Page in (
-                    WifiPage,
-                    EthernetPage,
-                    APPage,
-                    USBPage,
-                )
+                WifiPage,
+                EthernetPage,
+                APPage,
+                USBPage,
             ],
         )

--- a/pt_miniscreen/tiles/menu/settings.py
+++ b/pt_miniscreen/tiles/menu/settings.py
@@ -14,13 +14,10 @@ class SettingsMenuTile(MenuTile):
             size=size,
             pos=pos,
             pages=[
-                Page(size)
-                for Page in (
-                    SSHActionPage,
-                    VNCActionPage,
-                    FurtherLinkActionPage,
-                    APActionPage,
-                    HDMIResetPage,
-                )
+                SSHActionPage,
+                VNCActionPage,
+                FurtherLinkActionPage,
+                APActionPage,
+                HDMIResetPage,
             ],
         )

--- a/pt_miniscreen/tiles/menu/system.py
+++ b/pt_miniscreen/tiles/menu/system.py
@@ -8,10 +8,7 @@ class SystemMenuTile(MenuTile):
             size=size,
             pos=pos,
             pages=[
-                Page(size)
-                for Page in (
-                    BatteryPage,
-                    CPUPage,
-                )
+                BatteryPage,
+                CPUPage,
             ],
         )


### PR DESCRIPTION
| Status  | Ticket/Issue |
| :---: | :--: |
| Ready | [OS-1209](https://pi-top.atlassian.net/browse/OS-1209) |


#### Main changes
Add scrollbar hotspot to PaginatedTile. While PaginatedTile is
inheriting from ViewportTile it is not possible to add a hotspot that
scrolls independently of the pages, inherit from Tile instead. In order
for PaginatedTile to render the scrollbar hotspot as well as the
ViewportTile the `get_preprocess_image` method needs to be overridden.
This is so the initial image can have the pages ViewportTile's image
pasted in.

Override the PaginatedTile's `__setattr__` method in order to keep the
`active` state of the pages ViewportTile in sync.

Pass Page classes instead of instances to PaginatedTile so they can be
instantiated with the correct size. The size must now take the scrollbar
into account.

Some pages have crop and/or position issues due to the area to render
into becoming smaller. Fix some pages such as the Battery, Overview and
CPU pages and leave the rest. This is because a right gutter will be
added soon, and they will need to be adjusted again at that point.
