### PR TITLE
Create StateManager after setup_events, reverts a13f287

### DIFF
--- a/pt_miniscreen/app.py
+++ b/pt_miniscreen/app.py
@@ -48,9 +48,9 @@ class App:
 
         self._add_tile_group_to_stack_from_cls(HUDTileGroup)
 
-        self.state_manager = StateManager(self.miniscreen.contrast)
-
         self.setup_events()
+
+        self.state_manager = StateManager(self.miniscreen.contrast)
 
         logger.debug("Done initializing app")
 
@@ -112,6 +112,10 @@ class App:
             logger.debug(
                 f"Handling button {button} for tile group {self.current_tile_group}"
             )
+
+            if not getattr(self, 'state_manager'):
+                logger.info("Button press before State manager initialised")
+                return
 
             if not self.state_manager.buttons_should_be_handled():
                 logger.info("State manager says that buttons should not be handled")

--- a/pt_miniscreen/app.py
+++ b/pt_miniscreen/app.py
@@ -113,7 +113,7 @@ class App:
                 f"Handling button {button} for tile group {self.current_tile_group}"
             )
 
-            if not getattr(self, 'state_manager'):
+            if not getattr(self, "state_manager"):
                 logger.info("Button press before State manager initialised")
                 return
 

--- a/pt_miniscreen/app.py
+++ b/pt_miniscreen/app.py
@@ -113,7 +113,7 @@ class App:
                 f"Handling button {button} for tile group {self.current_tile_group}"
             )
 
-            if not getattr(self, "state_manager"):
+            if not getattr(self, "state_manager", None):
                 logger.info("Button press before State manager initialised")
                 return
 


### PR DESCRIPTION
| Status  | Ticket/Issue |
| :---: | :--: |
| Ready | - |


#### Main changes
- Reverts the change of https://github.com/pi-top/pi-top-4-Miniscreen/pull/207 and handles the issue differently. That change tried to ensure the hard dependency of setup_events on StateManager, but ignored the much greater soft dependency of StateManager's events on the setup_events handlers. As a result that change the pi-top splash animation wasn't shown because it's event was missed, and initial button presses were often not handled either. So now setup_events is first again, and just has a guard clause against handling buttons before StateManager is created.

#### Screenshots (feature, test output, profiling, dev tools etc)

[insert screenshots here]

#### Other notes (e.g. implementation quirks, edge cases, questions / issues)
-

#### Manual testing tips
-

#### Tag anyone who definitely needs to review or help
- @olivierwilkinson 
