### PR TITLE
fix: battery page memory leak

### DIFF
--- a/pt_miniscreen/pages/base.py
+++ b/pt_miniscreen/pages/base.py
@@ -20,6 +20,9 @@ class Page:
 
         self.hotspot_instances: List[HotspotInstance] = list()
 
+    def cleanup(self):
+        pass
+
     @property
     def size(self) -> Tuple:
         return self._size

--- a/pt_miniscreen/pages/system/battery.py
+++ b/pt_miniscreen/pages/system/battery.py
@@ -18,18 +18,27 @@ BATTERY_LEFT_MARGIN = 15
 CAPACITY_RECTANGLE_LEFT_OFFSET = 4
 CAPACITY_RECTANGLE_LEFT_MARGIN = BATTERY_LEFT_MARGIN + CAPACITY_RECTANGLE_LEFT_OFFSET
 
+# battery lives to the end of the process so we must create it globally to avoid
+# memory leaks
+battery = Battery()
+
 
 class Page(PageBase):
     def __init__(self, size):
-        self.battery = Battery()
-        self.cable_connected = self.battery.is_charging or self.battery.is_full
+        self.cable_connected = battery.is_charging or battery.is_full
         try:
-            self.capacity = self.battery.capacity
+            self.capacity = battery.capacity
         except Exception:
             self.capacity = 0
 
         super().__init__(size)
         self.reset()
+
+    def cleanup(self):
+        battery.on_capacity_change = None
+        battery.when_charging = None
+        battery.when_full = None
+        battery.when_discharging = None
 
     def reset(self):
         self.text_hotspot = TextHotspot(
@@ -98,7 +107,7 @@ class Page(PageBase):
             self.cable_connected = state in ("charging", "full")
             self.update_hotspots_properties()
 
-        self.battery.on_capacity_change = update_capacity
-        self.battery.when_charging = lambda: update_charging_state("charging")
-        self.battery.when_full = lambda: update_charging_state("full")
-        self.battery.when_discharging = lambda: update_charging_state("discharging")
+        battery.on_capacity_change = update_capacity
+        battery.when_charging = lambda: update_charging_state("charging")
+        battery.when_full = lambda: update_charging_state("full")
+        battery.when_discharging = lambda: update_charging_state("discharging")

--- a/pt_miniscreen/tiles/templates/paginated.py
+++ b/pt_miniscreen/tiles/templates/paginated.py
@@ -14,6 +14,12 @@ logger = logging.getLogger(__name__)
 class PaginatedTile(ViewportTile):
     SCROLL_PX_RESOLUTION = 2
 
+    def __del__(self):
+        super().__del__()
+
+        for page in self.pages:
+            page.cleanup()
+
     def __init__(self, size, pages, start_index=0, pos=(0, 0)):
         self.pages = pages
         self.page_index = start_index


### PR DESCRIPTION
| Status  | Ticket/Issue |
| :---: | :--: |
| Ready | [OS-1239](https://pi-top.atlassian.net/browse/OS-1239) |


#### Main changes

The Battery class uses long lived threads under the hood for it's
callbacks, for example the `on_capacity_change` callback. When passing
callbacks to the Battery self is referenced which creates a cirular
reference between the Battery and the Page class.

The Battery class also seems to have internal behaviour that prevents it
being garbage collected at all.

When navigating to the SystemMenu and back multiple times multiple
instances of BatteryPage are created but never garbage collected. This
causes a noticable performance impact over time.

Add a cleanup method to the Page class and implement it in BatteryPage
to remove the callbacks from the Battery. Removing the callbacks removes
the circular references and allows BatteryPage to be garbage collected.
Call the Page's cleanup method when it's parent PaginatedTile is garbage
collected.

Move the Battery to the module level rather than the class level. Since
Battery is never garbage collected creating a new Battery instance every
time BatteryPage is created also causes a memory leak. This has the
added benefit of speeding up the time it takes to create the SystemMenu.