### PR TITLE
Try except miniscreen reset

### DIFF
--- a/pt_miniscreen/app.py
+++ b/pt_miniscreen/app.py
@@ -227,7 +227,7 @@ class App:
         try:
             self.miniscreen.reset()
         except RuntimeError as e:
-            logger.error(f'Error resetting miniscreen: {e}')
+            logger.error(f"Error resetting miniscreen: {e}")
 
         if self.last_shown_image is not None:
             self.display(self.last_shown_image)

--- a/pt_miniscreen/app.py
+++ b/pt_miniscreen/app.py
@@ -224,7 +224,11 @@ class App:
     def reset(self) -> None:
         logger.info("Forcing full state refresh...")
         self.state_manager.wake()
-        self.miniscreen.reset()
+        try:
+            self.miniscreen.reset()
+        except RuntimeError as e:
+            logger.error(f'Error resetting miniscreen: {e}')
+
         if self.last_shown_image is not None:
             self.display(self.last_shown_image)
         logger.info("OLED control restored")


### PR DESCRIPTION
| Status  | Ticket/Issue |
| :---: | :--: |
| Ready | - |


#### Main changes
I've run into the below error twice today whilst testing the miniscreen control swaps, and it causes the main rendering thread to crash. We should catch this exception in the sdk too probably.

```
Feb 15 17:44:44 pi-top pt-miniscreen[816]: User has taken control of the miniscreen
Feb 15 17:45:21 pi-top pt-miniscreen[816]: User has given back control of the miniscreen
Feb 15 17:45:21 pi-top pt-miniscreen[816]: Forcing full state refresh...
Feb 15 17:45:21 pi-top pt-miniscreen[816]: Exception in thread Thread-21:
Feb 15 17:45:21 pi-top pt-miniscreen[816]: Traceback (most recent call last):
Feb 15 17:45:21 pi-top pt-miniscreen[816]:   File "/usr/lib/python3.9/threading.py", line 954, in _bootstrap_inner
Feb 15 17:45:21 pi-top pt-miniscreen[816]:     self.run()
Feb 15 17:45:21 pi-top pt-miniscreen[816]:   File "/usr/lib/python3.9/threading.py", line 892, in run
Feb 15 17:45:21 pi-top pt-miniscreen[816]:     self._target(*self._args, **self._kwargs)
Feb 15 17:45:21 pi-top pt-miniscreen[816]:   File "/usr/lib/python3/dist-packages/pt_miniscreen/app.py", line 186, in _main
Feb 15 17:45:21 pi-top pt-miniscreen[816]:     self.reset()
Feb 15 17:45:21 pi-top pt-miniscreen[816]:   File "/usr/lib/python3/dist-packages/pt_miniscreen/app.py", line 227, in reset
Feb 15 17:45:21 pi-top pt-miniscreen[816]:     self.miniscreen.reset()
Feb 15 17:45:21 pi-top pt-miniscreen[816]:   File "/usr/lib/python3/dist-packages/pitop/miniscreen/oled/oled.py", line 211, in reset
Feb 15 17:45:21 pi-top pt-miniscreen[816]:     self.refresh()
Feb 15 17:45:21 pi-top pt-miniscreen[816]:   File "/usr/lib/python3/dist-packages/pitop/miniscreen/oled/oled.py", line 203, in refresh
Feb 15 17:45:21 pi-top pt-miniscreen[816]:     self.__controller.reset_device()
Feb 15 17:45:21 pi-top pt-miniscreen[816]:   File "/usr/lib/python3/dist-packages/pitop/miniscreen/oled/core/device_controller.py", line 92, in reset_device
Feb 15 17:45:21 pi-top pt-miniscreen[816]:     self.lock.release()
Feb 15 17:45:21 pi-top pt-miniscreen[816]:   File "/usr/lib/python3/dist-packages/pitop/common/lock.py", line 58, in release
Feb 15 17:45:21 pi-top pt-miniscreen[816]:     self._thread_lock.release()
Feb 15 17:45:21 pi-top pt-miniscreen[816]: RuntimeError: release unlocked lock
Feb 15 17:45:58 pi-top pt-miniscreen[816]: User has given back control of the miniscreen
```