### PR TITLE
Improve action page error handling

### DIFF
--- a/pt_miniscreen/app.py
+++ b/pt_miniscreen/app.py
@@ -161,13 +161,13 @@ class App:
 
     def wait_for_stop(self) -> None:
         self.__stop_event.wait()
-        error = getattr(self, "__stop_error", None)
+        error = getattr(self, "_stop_error", None)
         if isinstance(error, Exception):
             raise error
 
     def stop(self, error: Optional[Exception] = None) -> None:
         logger.info("Stopping app...")
-        self.__stop_error = error
+        self._stop_error = error
         self.__stop_event.set()
 
     @property
@@ -219,6 +219,7 @@ class App:
             self.miniscreen.device.display(image)
         except (RuntimeError, BrokenPipeError) as e:
             # can't draw to miniscreen, reset won't help, just die
+            logger.error(f"app.display: {e}")
             self.stop(e)
 
     def reset(self) -> None:

--- a/pt_miniscreen/pages/templates/action/page.py
+++ b/pt_miniscreen/pages/templates/action/page.py
@@ -87,11 +87,6 @@ class Page(PageBase):
         if state == self.status_icon_hotspot.action_state:
             return
 
-        if state == ActionState.UNKNOWN:
-            # If unknown state is entered into after initialisation
-            # stay in that state until page is reset
-            return
-
         self.status_icon_hotspot.action_state = state
 
     def start_action(self) -> None:

--- a/pt_miniscreen/pages/templates/action/page.py
+++ b/pt_miniscreen/pages/templates/action/page.py
@@ -106,4 +106,5 @@ class Page(PageBase):
         try:
             self.set_state_method()
         except Exception as e:
-            logger.error(e)
+            self.action_state = ActionState.UNKNOWN
+            logger.error(f"Failed to start action: {e}")


### PR DESCRIPTION
When there's an error while running the action in an action page, the app would crashes but not restart since it doesn't exit with errors; `getattr` can't read/get name-mangled variables (the ones that start with `__`) so the error isn't propagated all the way to the top.

Also - use the action page & status icon `UNKNOWN` state, which draws a question mark in the status-circle when something goes wrong.