### PR TITLE
refactor: fix HUD giving children the wrong size

### DIFF
--- a/pt_miniscreen/pages/network/network_page_base.py
+++ b/pt_miniscreen/pages/network/network_page_base.py
@@ -42,7 +42,7 @@ class NetworkPageLayout:
     DEFAULT_FONT_SIZE = 12
     ICON_X_POS = 10
     MARGIN_X_LEFT = 30
-    MARGIN_X_RIGHT = 15
+    MARGIN_X_RIGHT = 5
     ICON_WIDTH = 12
     ICON_HEIGHT = 12
     icon_size = (ICON_WIDTH, ICON_HEIGHT)

--- a/pt_miniscreen/pages/templates/action/page.py
+++ b/pt_miniscreen/pages/templates/action/page.py
@@ -50,7 +50,6 @@ class Page(PageBase):
         FIRST_COLUMN_WIDTH = 50
 
         SECOND_COLUMN_POS = FIRST_COLUMN_POS + FIRST_COLUMN_WIDTH + SPACING
-        SECOND_COLUMN_WIDTH = self.size[0] - SECOND_COLUMN_POS
 
         if not callable(self.get_state_method):
             self.action_state = ActionState.IDLE
@@ -62,7 +61,7 @@ class Page(PageBase):
         self.hotspot_instances = [
             HotspotInstance(
                 TextHotspot(
-                    size=(SECOND_COLUMN_WIDTH, FONT_SIZE * 2),
+                    size=(FIRST_COLUMN_WIDTH, FONT_SIZE * 2),
                     text=self.text,
                     font_size=FONT_SIZE,
                     align="right",

--- a/pt_miniscreen/tile_groups/hud.py
+++ b/pt_miniscreen/tile_groups/hud.py
@@ -44,7 +44,8 @@ class HUDTileGroup(TileGroup):
 
     def handle_go_to_child(self, ChildMenuTile) -> None:
         previous_menu_tile = self.current_menu_tile
-        self.menu_tile_stack.append(ChildMenuTile(size=self.size, pos=(0, 0)))
+        child_tile_size = (self.size[0] - self.right_gutter_width, self.size[1])
+        self.menu_tile_stack.append(ChildMenuTile(size=child_tile_size, pos=(0, 0)))
         previous_menu_tile.active = False
         self.current_menu_tile.active = True
         self.set_gutter_icons()


### PR DESCRIPTION
When adding a title to the network pages I noticed that the size was incorrect for the pages. This PR fixes that issue separately from a feature.

#### Main changes

When adding the right gutter to the HUDTileGroup the size of child tiles
should have been reduced by the width of the gutter.

The gutter was manually accounted for in the child tiles and so this
does not change any user facing layout.

In the base network page the right margin had 10 extra pixels on it.

In the base action page the wrong column was actually passed to the
text, fixing this error actually caused the layout to be unchanged.
