### PR TITLE
feat: add boundary alignment to text hotspot

### DIFF
--- a/pt_miniscreen/pages/hud/overview.py
+++ b/pt_miniscreen/pages/hud/overview.py
@@ -93,8 +93,6 @@ class Page(PageBase):
             size=CAPACITY_TEXT_SIZE,
             text=get_capacity_text(),
             font_size=CAPACITY_FONT_SIZE,
-            anchor="lt",
-            xy=(0, 0),
         )
 
         self.ip_icon_hotspot = ImageHotspot(

--- a/pt_miniscreen/pages/system/battery.py
+++ b/pt_miniscreen/pages/system/battery.py
@@ -60,8 +60,6 @@ class Page(PageBase):
             size=TEXT_SIZE,
             text=get_capacity_text(),
             font_size=FONT_SIZE,
-            anchor="lt",
-            xy=(0, 0),
         )
 
         self.battery_hotspot = ImageHotspot(

--- a/pt_miniscreen/pages/templates/action/page.py
+++ b/pt_miniscreen/pages/templates/action/page.py
@@ -65,6 +65,7 @@ class Page(PageBase):
                     text=self.text,
                     font_size=FONT_SIZE,
                     align="right",
+                    vertical_align="center",
                 ),
                 (FIRST_COLUMN_POS, int(self.size[1] / 2) - FONT_SIZE),
             ),

--- a/pt_miniscreen/pages/templates/menu/page.py
+++ b/pt_miniscreen/pages/templates/menu/page.py
@@ -44,8 +44,6 @@ class Page(PageBase):
                     size=(self.width - TEXT_LEFT, FONT_SIZE),
                     text=self.text,
                     font_size=FONT_SIZE,
-                    anchor="lt",
-                    xy=(0, 0),
                 ),
                 (TEXT_LEFT, self.offset_pos_for_vertical_center(FONT_SIZE)),
             ),


### PR DESCRIPTION
Align text horizonally to boundaries when `align` is set. Options match
Pillow's `align` options: "left", "right" and "center" where "left" is
the default.

Add `vertical_align` property that aligns text similarly to `align` but
with vertical boundaries. Options are "top", "bottom" and "center" where
"top" is the default.

Set `vertical_align` to "center" in the base action page. Since the
previous default was to center the text horizontally and vertically the
action page text needs to be manually set to "center"

Remove `xy` and `anchor` properties since they are now superceded by the
align properties. Anchor is always left-top "lt" so that text xy
position can be calculated based off align values, text size and hotspot
size.

Incorperate MiniscreenAssistant logic into the TextHotspot. This allows
us to have greater control on the behaviour of the TextHotspot without
having to consider the impact of breaking changes.

Refactor the logic in the assistant for wrapping text and add it as a
`create_wrapped_text` method.

Memoize the `get_text_size` and `create_wrapped_text` methods since they
are called frequently and are potentially expensive.
