### PR TITLE
Reset DIM state timer on button press

### DIFF
--- a/pt_miniscreen/state.py
+++ b/pt_miniscreen/state.py
@@ -224,3 +224,4 @@ class StateManager:
             logger.debug("Waking up...")
             self.contrast_change_func(255)
             self.state = State.WAKING
+        self.reset_dim_timer()


### PR DESCRIPTION
| Status  | Ticket/Issue |
| :---: | :--: |
| Ready/Hold | [Ticket](https://pi-top.atlassian.net/browse/SWE-28) |


#### Main changes

Fix screensaver not being displayed by reseting the DIM state timer whenever a button is pressed. 

After the first time the app starts and the DIM state timer is set, the screensaver is displayed once it gets to the SCREENSAVER state. However, the app doesn't ever come back to those states since the DIM state timer isn't reset.

TODO: add tests

#### Screenshots (feature, test output, profiling, dev tools etc)

n/a

#### Other notes (e.g. implementation quirks, edge cases, questions / issues)
-

#### Manual testing tips
-

#### Tag anyone who definitely needs to review or help
-
