### PR TITLE
test: add difference in images to reporter

### DIFF
--- a/tests/plugins/snapshot_reporter.py
+++ b/tests/plugins/snapshot_reporter.py
@@ -1,7 +1,9 @@
 import pickle
+from io import BytesIO
 
 import pytest
 from imgcat import imgcat
+from PIL import Image, ImageChops
 
 
 def is_master(config):
@@ -79,3 +81,15 @@ class SnapshotReporter:
                 imgcat(failed_snapshot["expected"])
             else:
                 terminalreporter.write_line("None")
+
+            if failed_snapshot["received"] and failed_snapshot["expected"]:
+                try:
+
+                    image_received = Image.open(BytesIO(failed_snapshot["received"]))
+                    image_expected = Image.open(BytesIO(failed_snapshot["expected"]))
+                    difference = ImageChops.difference(image_received, image_expected)
+
+                    terminalreporter.write_line("Difference:")
+                    imgcat(difference)
+                except Exception:
+                    pass


### PR DESCRIPTION
#### Main changes
If a snapshot fails also show the difference between the expected and received images. This helps with failures that are due to a single pixel difference in the images which is difficult to see normally.

#### Screenshots (feature, test output, profiling, dev tools etc)
<img width="112" alt="Screenshot 2022-03-24 at 10 51 34" src="https://user-images.githubusercontent.com/15321261/159900866-a617c210-4254-40f0-9e2c-aba51205e63c.png">

