### PR TITLE
Get device IP using SDK

### DIFF
--- a/pt_miniscreen/pages/hud/overview.py
+++ b/pt_miniscreen/pages/hud/overview.py
@@ -2,8 +2,7 @@ import logging
 from math import ceil
 
 from pitop.battery import Battery
-from pitop.common.formatting import is_url
-from pitop.common.sys_info import get_internal_ip
+from pitop.common.sys_info import get_pi_top_ip
 
 from ...hotspots.base import HotspotInstance
 from ...hotspots.templates.image import Hotspot as ImageHotspot
@@ -67,11 +66,9 @@ def get_battery_image_path():
 
 
 def get_ip():
-    for interface in ("wlan0", "eth0", "ptusb0", "lo"):
-        ip_address = get_internal_ip(interface)
-        if is_url("http://" + ip_address):
-            return ip_address
-
+    ip_address = get_pi_top_ip()
+    if len(ip_address) > 0:
+        return ip_address
     return "No IP address"
 
 

--- a/tests/mocks/sys_info.py
+++ b/tests/mocks/sys_info.py
@@ -28,3 +28,7 @@ def get_ssh_enabled_state():
 
 def get_vnc_enabled_state():
     return "Disabled"
+
+
+def get_pi_top_ip():
+    return ""

--- a/tests/overview_test.py
+++ b/tests/overview_test.py
@@ -14,13 +14,10 @@ def battery():
 
 @pytest.fixture
 def internal_ip(mocker):
-    def patch(_interface, ip=""):
+    def patch(ip=""):
         mocker.patch(
-            "pt_miniscreen.pages.hud.overview.get_internal_ip",
-            lambda interface: ip if interface == _interface else "None",
-        )
-        mocker.patch(
-            "pt_miniscreen.pages.hud.overview.is_url", lambda url: url == f"http://{ip}"
+            "pt_miniscreen.pages.hud.overview.get_pi_top_ip",
+            return_value=ip,
         )
 
     return patch
@@ -52,18 +49,18 @@ def test_overview_battery(battery, miniscreen, snapshot):
 
 
 def test_overview_network(miniscreen, snapshot, internal_ip):
-    internal_ip("wlan0", "192.168.192.168")
+    internal_ip("192.168.192.168")
     sleep(4.5)
     snapshot.assert_match(miniscreen.device.display_image, "wifi.png")
 
-    internal_ip("eth0", "10.255.10.255")
+    internal_ip("10.255.10.255")
     sleep(4.5)
     snapshot.assert_match(miniscreen.device.display_image, "ethernet.png")
 
-    internal_ip("ptusb0", "172.31.172.31")
+    internal_ip("172.31.172.31")
     sleep(4.5)
     snapshot.assert_match(miniscreen.device.display_image, "usb.png")
 
-    internal_ip("lo", "127.0.0.1")
+    internal_ip("127.0.0.1")
     sleep(4.5)
     snapshot.assert_match(miniscreen.device.display_image, "localhost.png")


### PR DESCRIPTION
| Status  | Ticket/Issue |
| :---: | :--: |
| Ready/Hold | [Ticket](https://pi-top.atlassian.net/browse/<ticket-number>) |


#### Main changes
- Update how device IP is retrieved, using a new helper in the SDK https://github.com/pi-top/pi-top-Python-SDK/pull/521

#### Screenshots (feature, test output, profiling, dev tools etc)

N/A

#### Other notes (e.g. implementation quirks, edge cases, questions / issues)
-

#### Manual testing tips
- Install artifacts
- Install https://github.com/pi-top/pi-top-Python-SDK/pull/521 artifacts
- Restart miniscreen app `sudo systemctl restart pt-miniscreen`

#### Tag anyone who definitely needs to review or help
-
