### PR TITLE
Add test re-runner for flaky tests in pt miniscreen

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,8 +1,9 @@
-pytest
-pytest-cov
-pytest-mock
-pytest-xdist
-pytest-snapshot>=0.8.1
 Pillow>=8.1.2
 imgcat>=0.5.0
 psutil>=5.8.0
+pytest
+pytest-cov
+pytest-mock
+pytest-rerunfailures
+pytest-snapshot>=0.8.1
+pytest-xdist

--- a/tests/settings_test.py
+++ b/tests/settings_test.py
@@ -94,6 +94,7 @@ def setup(miniscreen, mocker):
     sleep(1)
 
 
+@pytest.mark.flaky(reruns=3)
 def test_ssh(miniscreen, snapshot):
     # enable ssh
     miniscreen.select_button.release()
@@ -110,6 +111,7 @@ def test_ssh(miniscreen, snapshot):
     snapshot.assert_match(miniscreen.device.display_image, "disabled.png")
 
 
+@pytest.mark.flaky(reruns=3)
 def test_vnc(miniscreen, snapshot):
     # scroll down to vnc page
     miniscreen.down_button.release()
@@ -130,6 +132,7 @@ def test_vnc(miniscreen, snapshot):
     snapshot.assert_match(miniscreen.device.display_image, "disabled.png")
 
 
+@pytest.mark.flaky(reruns=3)
 def test_further_link(miniscreen, snapshot):
     # scroll down to further link page
     miniscreen.down_button.release()
@@ -152,6 +155,7 @@ def test_further_link(miniscreen, snapshot):
     snapshot.assert_match(miniscreen.device.display_image, "disabled.png")
 
 
+@pytest.mark.flaky(reruns=3)
 def test_ap(miniscreen, snapshot):
     # scroll down to ap page
     miniscreen.down_button.release()
@@ -176,6 +180,7 @@ def test_ap(miniscreen, snapshot):
     snapshot.assert_match(miniscreen.device.display_image, "disabled.png")
 
 
+@pytest.mark.flaky(reruns=3)
 def test_hdmi_reset(miniscreen, snapshot):
     # scroll down to screen reset
     miniscreen.down_button.release()


### PR DESCRIPTION
| Status  | Ticket/Issue |
| :---: | :--: |
| Ready/Hold | [Ticket](https://pi-top.atlassian.net/browse/OS-1277) |


#### Main changes
- Use `pytest-rerunfailures` on flaky tests to re-run on failures. Most of the flaky tests I've found over the last week are in the settings page tests, so all of them are marked as flaky and will be re-run 3 times before considering them a failure.

#### Screenshots (feature, test output, profiling, dev tools etc)

[insert screenshots here]

#### Other notes (e.g. implementation quirks, edge cases, questions / issues)
-

#### Manual testing tips
-

#### Tag anyone who definitely needs to review or help
-
