### PR TITLE
test: fix flaky tests by grouping tests by file

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -55,4 +55,4 @@ profile = black
 max-line-length = 150
 
 [tool:pytest]
-addopts = -n auto
+addopts = -n auto --dist=loadfile


### PR DESCRIPTION
xdist by default doesn't group tests in each worker by file, instead
distributing them evenly. This means some tests from the same file can
be run at the same time which can cause flakiness if they share the same
global resource.
