### PR TITLE
fix: use threading.Event in marquee text

### DIFF
--- a/pt_miniscreen/core/components/marquee_text.py
+++ b/pt_miniscreen/core/components/marquee_text.py
@@ -1,6 +1,5 @@
 import logging
-from multiprocessing import Event
-from threading import Thread
+from threading import Event, Thread
 from time import sleep
 
 from PIL import Image


### PR DESCRIPTION
multiprocessing.Event was used by accident
