### PR TITLE
feat: allow updates to Component state during init

### DIFF
--- a/pt_miniscreen/core/component.py
+++ b/pt_miniscreen/core/component.py
@@ -130,6 +130,7 @@ class Component:
         )
         self._reconciliation_lock = threading.Lock()
         self._reconciliation_queued = False
+        self.rendered = False
         self.width = None
         self.height = None
         self.size = None
@@ -168,6 +169,9 @@ class Component:
 
             self._render_cache.output = output
 
+            # mark component as rendered
+            self.rendered = True
+
             return output
 
         self.render = render
@@ -202,16 +206,14 @@ class Component:
             self._reconciliation_queued = self._reconciliation_lock.locked()
             self._reconciliation_lock.acquire()
 
-            # bail if parent no longer exists
+            # do nothing if parent no longer exists
             on_rerender = self._get_on_rerender()
             if not callable(on_rerender):
                 return
 
-            # If render has never been called always notify parent about
-            # rerender. This necessary if parent is relying on child state to
-            # conditionally render it.
-            if not isinstance(self._render_cache.input, Image.Image):
-                return on_rerender()
+            # do nothing if component has never been rendered
+            if not self.rendered:
+                return
 
             render_output = self._unmodified_render(self._render_cache.input)
 
@@ -230,7 +232,9 @@ class Component:
     def _on_state_update(self, previous_state):
         if self.state != previous_state:
             self.on_state_change(previous_state)
-            self._reconcile()
+
+            if self.rendered:
+                self._reconcile()
 
     # lifecycle hooks
     def cleanup(self):

--- a/tests/core_text_component_test.py
+++ b/tests/core_text_component_test.py
@@ -144,7 +144,7 @@ def test_get_text(create_text, TextStore, render, snapshot):
     snapshot.assert_match(render(component), "updated-text-1.png")
 
     # text updated again after another second
-    sleep(1)
+    sleep(1.1)
     snapshot.assert_match(render(component), "updated-text-2.png")
 
 
@@ -160,7 +160,7 @@ def test_get_text_interval(create_text, TextStore, render, snapshot):
     snapshot.assert_match(render(component), "updated-text-1.png")
 
     # text updated again after another half a second
-    sleep(0.5)
+    sleep(0.6)
     snapshot.assert_match(render(component), "updated-text-2.png")
 
 


### PR DESCRIPTION
Currently updating Component state at any time triggers a
reconciliation. If state is updated during or soon after initialisation
the reconciliation can cause errors since not all components in the
parent are guaranteed to have been created, or it might conflict with
the initial render that sets up the render cache.

To prevent reconciliation issues during creation don't reconcile until
the Component has been rendered for the first time. This also aligns
better with what reconciliation is meant to be: checking if the render
output has changed and to notify the parent if so.

Add a boolean attribute `rendered` to the Component class to allow
Components to know if the parent has rendered them. This is useful
generally as before being rendered it doesn't make sense to animate
something, and after it is rendered it has a size.

The reason reconciliation is fired when the component has not been
rendered yet is to handle the case where the parent relies on the
child's state to conditionally render the child. This was done to be
tolerant to learners who may not have a good idea of how to organise
state yet. However on closer inspection it only works some of the time,
after initial render the parent is no longer updated when the child
updates.

For now remove the ability of parents to be notified by child component
updates unless the child component has changed it's output. There maybe
a better way to handle this that is more tolerant but for now it is the
most consistent behaviour.