### PR TITLE
Component pausing

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -156,12 +156,25 @@ def parent():
         def dummy(self):
             pass
 
-    return Parent()
+        def render(self, image):
+            for child in self._children:
+                image = child.render(image)
+
+            return image
+
+    parent = Parent()
+    parent._set_active(True)
+    return parent
 
 
 @pytest.fixture
 def create_component(parent):
-    return lambda Component, **kwargs: Component(on_rerender=parent.dummy, **kwargs)
+    def create(Component, **kwargs):
+        component = Component(on_rerender=parent.dummy, **kwargs)
+        component._set_active(True)
+        return component
+
+    return create
 
 
 @pytest.fixture

--- a/pt_miniscreen/core/app.py
+++ b/pt_miniscreen/core/app.py
@@ -25,6 +25,7 @@ class App:
 
     def start(self):
         self.root = self.Root(on_rerender=self.display)
+        self.root._set_active(True)
         self.display()
 
     def stop(self):

--- a/pt_miniscreen/core/components/image.py
+++ b/pt_miniscreen/core/components/image.py
@@ -79,6 +79,8 @@ class Image(Component):
         while True:
             sleep(self._image.info["duration"] / 1000)
 
+            self.active_event.wait()
+
             if stop_event.is_set():
                 return
 

--- a/pt_miniscreen/core/components/marquee_text.py
+++ b/pt_miniscreen/core/components/marquee_text.py
@@ -57,6 +57,8 @@ class MarqueeText(Text):
         scroll_len = max(text_size[0] - self.width, 0)
 
         for offset in carousel(scroll_len, step=self.state["step"]):
+            self.active_event.wait()
+
             sleep(self.state["step_time"])
             if stop_event.is_set():
                 return

--- a/tests/core_app_test.py
+++ b/tests/core_app_test.py
@@ -117,6 +117,6 @@ def test_stop(app):
     assert root_child() is None
 
     # intervals are cleaned up after their wait time elapses
-    sleep(1)
+    sleep(1.1)
     assert root_interval() is None
     assert child_interval() is None

--- a/tests/core_image_component_test.py
+++ b/tests/core_image_component_test.py
@@ -87,6 +87,20 @@ def test_animated_image(create_image, render, get_test_image_path, snapshot):
     sleep(0.55)
     snapshot.assert_match(render(component), "frame-1.png")
 
+    # stops animating when component is paused
+    component._set_active(False)
+    sleep(0.55)
+    snapshot.assert_match(render(component), "frame-1.png")
+    sleep(0.55)
+    snapshot.assert_match(render(component), "frame-1.png")
+
+    # starts animating again when component is unpaused
+    component._set_active(True)
+    sleep(0.55)
+    snapshot.assert_match(render(component), "frame-1.png")
+    sleep(0.55)
+    snapshot.assert_match(render(component), "frame-2.png")
+
     # can create image without looping
     component = create_image(image_path=get_test_image_path("test.gif"), loop=False)
     snapshot.assert_match(render(component), "frame-1.png")

--- a/tests/core_list_component_test.py
+++ b/tests/core_list_component_test.py
@@ -773,6 +773,54 @@ def test_virtual_list_visible_rows_attribute(
     assert component.rows == component.visible_rows
 
 
+def test_row_pausing(create_list, create_rows, render):
+    component = create_list(Rows=create_rows(4), num_visible_rows=2)
+
+    # rows are not active before list is rendered
+    for row in component.rows:
+        assert row.active_event.is_set() is False
+
+    # only visible rows become active when rendered
+    render(component)
+
+    assert component.rows[0].active_event.is_set()
+    assert component.rows[1].active_event.is_set()
+    assert component.rows[2].active_event.is_set() is False
+    assert component.rows[3].active_event.is_set() is False
+
+    # correct rows are active after scrolling down
+    component.scroll_down()
+    sleep(0.30)
+    assert component.rows[0].active_event.is_set() is False
+    assert component.rows[1].active_event.is_set()
+    assert component.rows[2].active_event.is_set()
+    assert component.rows[3].active_event.is_set() is False
+
+    # correct rows are active after scrolling up
+    component.scroll_up()
+    sleep(0.30)
+    assert component.rows[0].active_event.is_set()
+    assert component.rows[1].active_event.is_set()
+    assert component.rows[2].active_event.is_set() is False
+    assert component.rows[3].active_event.is_set() is False
+
+    # correct rows are active after scrolling down with a distance more than one
+    component.scroll_down(distance=2)
+    sleep(0.30)
+    assert component.rows[0].active_event.is_set() is False
+    assert component.rows[1].active_event.is_set() is False
+    assert component.rows[2].active_event.is_set()
+    assert component.rows[3].active_event.is_set()
+
+    # correct rows are active after scrolling up with a distance more than one
+    component.scroll_up(distance=2)
+    sleep(0.30)
+    assert component.rows[0].active_event.is_set()
+    assert component.rows[1].active_event.is_set()
+    assert component.rows[2].active_event.is_set() is False
+    assert component.rows[3].active_event.is_set() is False
+
+
 def test_cleanup(parent, create_rows, render):
     from pt_miniscreen.core.components import List
 

--- a/tests/core_marquee_text_component_test.py
+++ b/tests/core_marquee_text_component_test.py
@@ -286,6 +286,20 @@ def test_scrolling(mocker, create_marquee_text, render, snapshot):
     sleep(0.115)
     snapshot.assert_match(render(component), "wide-text-2.png")
 
+    # stops scrolling when component is paused
+    component._set_active(False)
+    sleep(0.115)
+    snapshot.assert_match(render(component), "wide-text-3.png")
+    sleep(0.115)
+    snapshot.assert_match(render(component), "wide-text-3.png")
+
+    # starts scrolling again when component is unpaused
+    component._set_active(True)
+    sleep(0.115)
+    snapshot.assert_match(render(component), "wide-text-2.png")
+    sleep(0.115)
+    snapshot.assert_match(render(component), "wide-text-1.png")
+
     # stops scrolling when text changes to be thinner than image
     component.state.update({"text": "Small width"})
     sleep(0.15)

--- a/tests/core_smoke_test.py
+++ b/tests/core_smoke_test.py
@@ -103,13 +103,13 @@ def test_smoke(snapshot, Root):
     snapshot.assert_match(app.miniscreen.device.display_image, "update.png")
 
     # shows updates from an interval
-    sleep(1)
+    sleep(1.1)
     snapshot.assert_match(app.miniscreen.device.display_image, "interval-update.png")
 
     # does not show changes when stopped
     app.stop()
     counter.state.update({"count": 1})
-    sleep(1)
+    sleep(1.1)
     snapshot.assert_match(app.miniscreen.device.display_image, "stopped.png")
 
     # can start app again


### PR DESCRIPTION
| Status  | Ticket/Issue |
| :---: | :--: |
| Ready | [None](https://pi-top.atlassian.net/browse/<ticket-number>) |


#### Main changes
- pause components when not rendered

Intervals running in the background that do not change what is being
displayed on the screen cause performance to drop as an application
scales.

Pause components when they are not being rendered. Pausing a component
means that it's intervals will wait until the component becomes active
again to continue. We know that a component can be paused when it is not
being rendered, since it will never change the output of it's parent.

To track whether a component is being rendered we need to know if it's
render method is called by it's parent's render method. To do this we
can have components mark themselves as rendered whenever their render
method is called. Parents can use this by marking their children as not
rendered before it's render method is called and then check which
children are marked as rendered afterwards. To do this tracking of
whether a component is rendered use the existing `rendered` property.

After rendering or reconciling, a parent needs to set the active state
of it's children based off whether they are rendered or not.

To replace the previous usage of the `rendered` property a new `mounted`
property has been added, this is used to verify reconciliation should
happen and that the render cache is populated.

In order to allow custom threads to hook into this pausing behaviour the
`active_event` that is used to pause intervals has been exposed. One way
to pause a custom thread using this event is to wait for it to become
active by calling `self.active_event.wait`.

- pause image gif animations when not active

When the Image component is rendering an animated image it uses a custom
thread in order to vary the wait time between frames. Use the
`active_event` to pause the thread when the component is not active.

- pause marquee text scrolling when not active

The MarqueeText component uses a custom thread to move the text back and
forth. Use the `active_event` to wait until the component becomes active
to move the text.

- only render list rows that will be shown

In order for list rows that are not visible to be paused they must not
be rendered. Currently when the list is not virtual we render all the
rows to then crop the window. Instead of rendering all rows we can
instead determine the exact rows that are needed and only render those
before cropping the window.

- fix running app suites independently

When only running tests for the app such as `tests/system_test.py` the
setup is broken. It seems like these test rely on a core test suite to
be run as well, presumably because the `setup` fixture needs to be run
before a test that uses the `app` fixture.

Ensure the `app` fixture performs all necessary setup itself so the app
suites can be run independently of the core suites.