### PR TITLE
Control pt-web-vnc-desktop in VNC action page

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -19,7 +19,7 @@ Recommends:
  autorandr (>= 1.9),
  further-link,
 # Control desktop sharing via browser
- pt-web-vnc,
+ pt-web-vnc (>= 0.0.2),
 # Control Wi-Fi AP mode
  wifi-ap-sta,
 # Used for closing 'Screen Layout Editor' when resetting display

--- a/debian/control
+++ b/debian/control
@@ -18,6 +18,8 @@ Depends:
 Recommends:
  autorandr (>= 1.9),
  further-link,
+# Control desktop sharing via browser
+ pt-web-vnc,
 # Control Wi-Fi AP mode
  wifi-ap-sta,
 # Used for closing 'Screen Layout Editor' when resetting display

--- a/pt_miniscreen/actions.py
+++ b/pt_miniscreen/actions.py
@@ -35,6 +35,12 @@ def change_ssh_enabled_state():
 def change_vnc_enabled_state():
     __change_service_enabled_state("vncserver-x11-serviced.service")
 
+    # Force vncserver-x11-serviced and pt-web-vnc-desktop services status to match
+    vncserver_state = get_systemd_enabled_state("vncserver-x11-serviced.service")
+    pt_web_vnc_state = get_systemd_enabled_state("pt-web-vnc-desktop.service")
+    if vncserver_state != pt_web_vnc_state:
+        __change_service_enabled_state("pt-web-vnc-desktop.service")
+
 
 def change_further_link_enabled_state():
     __change_service_enabled_state("further-link.service")

--- a/tests/mocks/sys_info.py
+++ b/tests/mocks/sys_info.py
@@ -14,7 +14,7 @@ def get_network_strength(interface):
     return "0%"
 
 
-def get_systemd_enabled_state():
+def get_systemd_enabled_state(service):
     return "Disabled"
 
 

--- a/tests/settings_test.py
+++ b/tests/settings_test.py
@@ -16,6 +16,7 @@ class SettingsState:
             "ssh",
             "further-link.service",
             "vncserver-x11-serviced.service",
+            "pt-web-vnc-desktop.service",
         ):
             self.service_state[service] = "Disabled"
         self.ap_mode_status["state"] = "Inactive"
@@ -69,6 +70,10 @@ def setup(miniscreen, mocker):
     mocker.patch(
         "pt_miniscreen.pages.settings.vnc_toggle.get_vnc_enabled_state",
         partial(settings_manager.get_status, "vncserver-x11-serviced.service"),
+    )
+    mocker.patch(
+        "pt_miniscreen.pages.settings.vnc_toggle.get_vnc_enabled_state",
+        partial(settings_manager.get_status, "pt-web-vnc-desktop.service"),
     )
     mocker.patch(
         "pt_miniscreen.pages.settings.further_link_toggle.get_pt_further_link_enabled_state",


### PR DESCRIPTION
| Status  | Ticket/Issue |
| :---: | :--: |
| Ready/Hold | [Ticket](https://pi-top.atlassian.net/browse/OS-1332) |


#### Main changes
- VNC toggle in the Settings Page also controls the `pt-web-vnc-desktop` systemd service.

#### Screenshots (feature, test output, profiling, dev tools etc)

[insert screenshots here]

#### Other notes (e.g. implementation quirks, edge cases, questions / issues)
-

#### Manual testing tips
-

#### Tag anyone who definitely needs to review or help
-
