### PR TITLE
Fix button handler crash

### DIFF
--- a/pt_miniscreen/app.py
+++ b/pt_miniscreen/app.py
@@ -21,6 +21,12 @@ class App(BaseApp):
         logger.debug("Initializing miniscreen...")
         miniscreen = Pitop().miniscreen
 
+        logger.debug("Initialising app...")
+        super().__init__(miniscreen, Root=RootComponent)
+
+    def start():
+        super().start()
+
         def set_is_user_controlled(user_has_control) -> None:
             if user_has_control:
                 self.stop_timers()
@@ -31,18 +37,18 @@ class App(BaseApp):
                 f"User has {'taken' if user_has_control else 'given back'} control of the miniscreen"
             )
 
-        miniscreen.when_user_controlled = lambda: set_is_user_controlled(True)
-        miniscreen.when_system_controlled = lambda: set_is_user_controlled(False)
-        miniscreen.select_button.when_released = self.create_button_handler(
+        self.miniscreen.when_user_controlled = lambda: set_is_user_controlled(True)
+        self.miniscreen.when_system_controlled = lambda: set_is_user_controlled(False)
+        self.miniscreen.select_button.when_released = self.create_button_handler(
             self.handle_select_button_release
         )
-        miniscreen.cancel_button.when_released = self.create_button_handler(
+        self.miniscreen.cancel_button.when_released = self.create_button_handler(
             self.handle_cancel_button_release
         )
-        miniscreen.up_button.when_released = self.create_button_handler(
+        self.miniscreen.up_button.when_released = self.create_button_handler(
             self.handle_up_button_release
         )
-        miniscreen.down_button.when_released = self.create_button_handler(
+        self.miniscreen.down_button.when_released = self.create_button_handler(
             self.handle_down_button_release
         )
 
@@ -50,9 +56,6 @@ class App(BaseApp):
         self.screensaver_timer = None
         self.dimming_timer = None
         self.start_dimming_timer()
-
-        logger.debug("Initialising app...")
-        super().__init__(miniscreen, Root=RootComponent)
 
     def brighten(self):
         self.miniscreen.contrast(255)

--- a/pt_miniscreen/app.py
+++ b/pt_miniscreen/app.py
@@ -24,7 +24,7 @@ class App(BaseApp):
         logger.debug("Initialising app...")
         super().__init__(miniscreen, Root=RootComponent)
 
-    def start():
+    def start(self):
         super().start()
 
         def set_is_user_controlled(user_has_control) -> None:
@@ -73,13 +73,18 @@ class App(BaseApp):
 
             self.restart_dimming_timer()
 
-            if self.root.is_screensaver_running:
-                self.root.stop_screensaver()
-                self.brighten()
-                return
+            try:
+                if self.root.is_screensaver_running:
+                    self.root.stop_screensaver()
+                    self.brighten()
+                    return
 
-            if callable(func):
-                func()
+                if callable(func):
+                    func()
+
+            except Exception as e:
+                logger.error("Error in button handler: " + str(e))
+                self.stop(e)
 
             if self.dimmed:
                 self.brighten()


### PR DESCRIPTION
| Status  | Ticket/Issue |
| :---: | :--: |
| Ready | no Ticket |

This was prompted by the following error, which I've seen before. It can be triggered if you press a button before the app is started. app.root is not created until the start method is called but the interactions created in init are expecting it to exist.
```
Aug 15 12:24:00 pi-top systemd[1]: Starting pi-top OLED system menu...
Aug 15 12:24:03 pi-top systemd[1]: Started pi-top OLED system menu.
Aug 15 12:24:07 pi-top pt-miniscreen[9813]: Exception in thread Thread-6:
Aug 15 12:24:07 pi-top pt-miniscreen[9813]: Traceback (most recent call last):
Aug 15 12:24:07 pi-top pt-miniscreen[9813]:   File "/usr/lib/python3.9/threading.py", line 954, in _bootstrap_inner
Aug 15 12:24:07 pi-top pt-miniscreen[9813]:     self.run()
Aug 15 12:24:07 pi-top pt-miniscreen[9813]:   File "/usr/lib/python3.9/threading.py", line 892, in run
Aug 15 12:24:07 pi-top pt-miniscreen[9813]:     self._target(*self._args, **self._kwargs)
Aug 15 12:24:07 pi-top pt-miniscreen[9813]:   File "/usr/lib/python3/dist-packages/pitop/common/ptdm.py", line 460, in __thread_method
Aug 15 12:24:07 pi-top pt-miniscreen[9813]:     self.invoke_callback_func_if_exists(
Aug 15 12:24:07 pi-top pt-miniscreen[9813]:   File "/usr/lib/python3/dist-packages/pitop/common/ptdm.py", line 476, in invoke_callback_func_if_exists
Aug 15 12:24:07 pi-top pt-miniscreen[9813]:     func()
Aug 15 12:24:07 pi-top pt-miniscreen[9813]:   File "/usr/lib/python3/dist-packages/pitop/miniscreen/miniscreen.py", line 51, in <lambda>
Aug 15 12:24:07 pi-top pt-miniscreen[9813]:     Message.PUB_V3_BUTTON_DOWN_RELEASED: lambda: set_button_state(
Aug 15 12:24:07 pi-top pt-miniscreen[9813]:   File "/usr/lib/python3/dist-packages/pitop/miniscreen/miniscreen.py", line 34, in set_button_state
Aug 15 12:24:07 pi-top pt-miniscreen[9813]:     self.__ptdm_subscribe_client.invoke_callback_func_if_exists(
Aug 15 12:24:07 pi-top pt-miniscreen[9813]:   File "/usr/lib/python3/dist-packages/pitop/common/ptdm.py", line 476, in invoke_callback_func_if_exists
Aug 15 12:24:07 pi-top pt-miniscreen[9813]:     func()
Aug 15 12:24:07 pi-top pt-miniscreen[9813]:   File "/usr/lib/python3/dist-packages/pt_miniscreen/app.py", line 73, in handler
Aug 15 12:24:07 pi-top pt-miniscreen[9813]:     if self.root.is_screensaver_running:
Aug 15 12:24:07 pi-top pt-miniscreen[9813]: AttributeError: 'App' object has no attribute 'root'
```


#### Main changes
- [Create app interactions in start rather than init, after root is created](https://github.com/pi-top/pi-top-4-Miniscreen/commit/12dc6f3d4d65bce35ace138e19b9327e1ee7b931)
- [Catch button handler errors to keep app interactive if one fails](https://github.com/pi-top/pi-top-4-Miniscreen/commit/5c4260f9f1c411bc5dd5cd10b193bc768ddaa492)

