### PR TITLE
Set package version using environment variable

### DIFF
--- a/.github/workflows/deb-build.yml
+++ b/.github/workflows/deb-build.yml
@@ -65,6 +65,7 @@ jobs:
           additional_env: |
             DATA="${{ secrets.DATA }}"
             TLS_KEY="${{ secrets.TLS_KEY }}"
+            PYTHON_PYTHON_PACKAGE_VERSION="${{ steps.version.outputs.tag_latest_ltrimv }}"
 
       - name: Generate artifact name
         run: |

--- a/.github/workflows/deb-release.yml
+++ b/.github/workflows/deb-release.yml
@@ -67,6 +67,7 @@ jobs:
           additional_env: |
             DATA="${{ secrets.DATA }}"
             TLS_KEY="${{ secrets.TLS_KEY }}"
+            PYTHON_PACKAGE_VERSION="${{ env.CURRENT_VERSION }}"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3

--- a/pt_miniscreen/__init__.py
+++ b/pt_miniscreen/__init__.py
@@ -1,0 +1,1 @@
+from .version import __version__

--- a/pt_miniscreen/version.py
+++ b/pt_miniscreen/version.py
@@ -1,0 +1,7 @@
+from pkg_resources import get_distribution
+
+__version__ = "N/A"
+try:
+    __version__ = get_distribution("pt_miniscreen").version
+except Exception:
+    pass

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [metadata]
 name = pt-miniscreen
-version = 5.0.0
 description = pi-top [4] Miniscreen App
 long_description = file: README.rst
 long_description_content_type = text/x-rst

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,12 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from os import environ
+
 import setuptools
 
 if __name__ == "__main__":
-    setuptools.setup(scripts=["scripts/pt-miniscreen-should-start"])
+    setuptools.setup(
+        scripts=["scripts/pt-miniscreen-should-start"],
+        version=environ.get("PYTHON_PACKAGE_VERSION", "0.0.1.dev1").replace('"', ""),
+    )


### PR DESCRIPTION
| Status  | Ticket/Issue |
| :---: | :--: |
| Ready/Hold | [Ticket](https://pi-top.atlassian.net/browse/<ticket-number>) |


#### Main changes
Set package version on build-time using the `PYTHON_PACKAGE_VERSION` environment variable:
- Update workflows to provide this variable when building the package. In these workflows, the version is generated to either provide a snapshot changelog (on PR builds) or read from the actual changelog file (on release builds).
- The python module now provides `__version__`. It reports the package version using `pkg_resources.get_distribution`. This assumes the package is installed in the system. 

#### Screenshots (feature, test output, profiling, dev tools etc)

[insert screenshots here]

#### Other notes (e.g. implementation quirks, edge cases, questions / issues)
-

#### Manual testing tips
-

#### Tag anyone who definitely needs to review or help
-
