### PR TITLE
Reset screen on PUB_PITOPD_READY event

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -23,16 +23,16 @@ def patch_packages():
         "pitop.common.firmware_device",
         "pitop.common.formatting",
         "pitop.common.pt_os",
-        "pitop.common.ptdm",
         "pitop.common.switch_user",
     ]
     for module in modules_to_patch:
         modules[module] = MagicMock()
 
     # packages that need to be patched in tests
-    from tests.mocks import battery, pitop, sys_info
+    from tests.mocks import battery, pitop, sys_info, ptdm
 
     modules["pitop.common.sys_info"] = sys_info
+    modules["pitop.common.ptdm"] = ptdm
     modules["pitop.battery"] = battery
     modules["pitop.system.pitop"] = pitop
 

--- a/conftest.py
+++ b/conftest.py
@@ -18,11 +18,12 @@ def patch_packages():
         "pitop",
         "pitop.common.command_runner",
         "pitop.common.common_ids",
-        "pitop.common.current_session_info",
         "pitop.common.configuration_file",
+        "pitop.common.current_session_info",
         "pitop.common.firmware_device",
         "pitop.common.formatting",
         "pitop.common.pt_os",
+        "pitop.common.ptdm",
         "pitop.common.switch_user",
     ]
     for module in modules_to_patch:

--- a/tests/core_app_test.py
+++ b/tests/core_app_test.py
@@ -121,6 +121,14 @@ def test_stop(app):
     assert child_interval() is None
 
 
+def test_subscribes_to_pitopd_ready_event(app):
+    from pitop.common.ptdm import Message
+
+    app.start()
+    callback = app._ptdm_subscribe_client.subs.get(Message.PUB_PITOPD_READY)
+    assert callback is not None
+
+
 def test_on_pitopd_initialization_callback(app):
     from pitop.common.ptdm import Message
 
@@ -129,7 +137,6 @@ def test_on_pitopd_initialization_callback(app):
     app.miniscreen.reset = MagicMock()
 
     callback = app._ptdm_subscribe_client.subs.get(Message.PUB_PITOPD_READY)
-    assert callback is not None
 
     assert app.display.call_count == 0
     assert app.miniscreen.reset.call_count == 0

--- a/tests/core_app_test.py
+++ b/tests/core_app_test.py
@@ -119,3 +119,22 @@ def test_stop(app):
     sleep(1.1)
     assert root_interval() is None
     assert child_interval() is None
+
+
+def test_on_pitopd_initialization_callback(app):
+    from pitop.common.ptdm import Message
+
+    app.start()
+    app.display = MagicMock()
+    app.miniscreen.reset = MagicMock()
+
+    callback = app._ptdm_subscribe_client.subs.get(Message.PUB_PITOPD_READY)
+    assert callback is not None
+
+    assert app.display.call_count == 0
+    assert app.miniscreen.reset.call_count == 0
+
+    callback()
+
+    assert app.display.call_count == 1
+    assert app.miniscreen.reset.call_count == 1

--- a/tests/core_component_test.py
+++ b/tests/core_component_test.py
@@ -9,7 +9,6 @@ from weakref import ref
 import pytest
 from PIL import Image
 
-from pt_miniscreen.core.component import RenderException
 
 logger = logging.getLogger(__name__)
 
@@ -345,6 +344,7 @@ def test_pausing(parent, SpotComponent):
 
 def test_render_exceptions(parent, SpotComponent, render):
     from pt_miniscreen.core import Component
+    from pt_miniscreen.core.component import RenderException
 
     class NoReturn(Component):
         def render(self, image):

--- a/tests/core_utils_test.py
+++ b/tests/core_utils_test.py
@@ -1,18 +1,12 @@
-import pytest
+def test_carousel_step():
+    from pt_miniscreen.core.utils import carousel
 
-from pt_miniscreen.core.utils import carousel
-
-
-@pytest.mark.parametrize(
-    "expected_iter,carousel_iter",
-    [
+    for expected_output, carousel_output in [
         [iter([1, 2, 3, 2, 1, 0, 1]), carousel(start=0, end=3, step=1)],
         [iter([3, 4, 3, 2, 3, 4]), carousel(start=2, end=4, step=1)],
         [iter([1, 0, 1, 0, 1, 0]), carousel(start=0, end=1, step=1)],
         [iter([2, 4, 5, 3, 1, 0]), carousel(start=0, end=5, step=2)],
         [iter([30, 38, 8, 0, 30, 38, 8]), carousel(start=0, end=38, step=30)],
-    ],
-)
-def test_carousel_step(expected_iter, carousel_iter):
-    for expected_value, output_value in zip(expected_iter, carousel_iter):
-        assert expected_value == output_value
+    ]:
+        for expected_value, output_value in zip(expected_output, carousel_output):
+            assert expected_value == output_value

--- a/tests/mocks/ptdm.py
+++ b/tests/mocks/ptdm.py
@@ -1,0 +1,19 @@
+from enum import Enum, auto
+from typing import Dict
+
+
+class Message(Enum):
+    PUB_PITOPD_READY = auto()
+
+
+class PTDMSubscribeClient:
+    subs: Dict = {}
+
+    def initialise(self, message_to_func_dict: Dict) -> None:
+        self.subs.update(message_to_func_dict)
+
+    def start_listening(self) -> None:
+        pass
+
+    def stop_listening(self) -> None:
+        pass


### PR DESCRIPTION
| Status  | Ticket/Issue |
| :---: | :--: |
| Ready/Hold | [Ticket](https://pi-top.atlassian.net/browse/OS-1379) |


#### Main changes

Currently when `pi-topd` starts, it sets some parameters associated to the miniscreen (SPI bus, OLED controller, ...) and then resets the screen, causing the OLED to go to black. 

`pt-miniscreen` will now handle this scenario by subscribing to the `PUB_PITOPD_READY` event (published by `pi-topd` once it's initialized) and then resetting the miniscreen and displaying the latest known image.

#### Screenshots (feature, test output, profiling, dev tools etc)

[insert screenshots here]

#### Other notes (e.g. implementation quirks, edge cases, questions / issues)
-

#### Manual testing tips
-

#### Tag anyone who definitely needs to review or help
-
