### PR TITLE
fix: sped up menu gif after scroll

### DIFF
--- a/pt_miniscreen/root.py
+++ b/pt_miniscreen/root.py
@@ -43,6 +43,7 @@ class RootPageList(PageList):
     def __init__(self, **kwargs):
         super().__init__(
             **kwargs,
+            use_snapshot_when_scrolling=False,
             Pages=[
                 OverviewPage,
                 SystemMenuPage,


### PR DESCRIPTION
When scrolling through the Root pages the first frame of the gifs don't wait for the full duration before changing, giving the appearance that they are sped up initially.

This is due to the default behaviour of the core List component: it uses a snapshot of the scrolling rows to improve performance for complex rows, this snapshot remains on the first frame longer than the gif does, giving the illusion of it being sped up once scrolling finishes.

Turn off this behaviour of the List by setting
`use_snapshot_when_scrolling` to `False` so that the gif animates while scrolling, keeping frame time consistent.
