### PR TITLE
fix: prevent assigning to Component.state

### DIFF
--- a/pt_miniscreen/core/component.py
+++ b/pt_miniscreen/core/component.py
@@ -135,7 +135,7 @@ class Component:
         self._intervals = []
         self._render_cache = RenderCache()
         self._get_on_rerender = WeakMethod(on_rerender)
-        self.state = State(
+        self._state = State(
             initial_state={**self.default_state, **initial_state},
             on_state_update=self._on_state_update,
         )
@@ -289,6 +289,16 @@ class Component:
         pass
 
     # external API
+    @property
+    def state(self):
+        return self._state
+
+    @state.setter
+    def state(self, value):
+        raise AttributeError(
+            "Component.state cannot be set, pass initial_state to super().__init__ or call self.state.update"
+        )
+
     def create_child(self, ChildComponent, **kwargs):
         child = ChildComponent(**kwargs, on_rerender=self._reconcile)
         self._children.append(child)

--- a/tests/core_component_test.py
+++ b/tests/core_component_test.py
@@ -130,6 +130,17 @@ def test_state(parent):
     # state is a dictionary
     assert isinstance(component.state, dict)
 
+    # state cannot be assigned to
+    try:
+        component.state = None
+    except AttributeError as e:
+        assert (
+            str(e)
+            == "Component.state cannot be set, pass initial_state to super().__init__ or call self.state.update"
+        )
+    finally:
+        assert component.state is not None
+
     # state has same equality behaviour as a normal dict
     assert component.state == {"foo": "bar", "deep": {"foo": "bar"}}
 


### PR DESCRIPTION
Assigning to Component.state breaks the internal representation of a component and prevents it from notifying the parent of a change.

Raise a helpful error when a user tries to assign to `state`.
