### PR TITLE
Don't fail if firmware updater isn't installed

### DIFF
--- a/pt_miniscreen/pages/system/last_update.py
+++ b/pt_miniscreen/pages/system/last_update.py
@@ -6,11 +6,6 @@ from pitop.common.firmware_device import FirmwareDevice
 from pitop.common.common_names import FirmwareDeviceName
 from pitop.common.common_ids import FirmwareDeviceID
 from pitop.common.sys_info import get_pi_top_ip
-from pt_fw_updater.utils import (
-    default_firmware_folder,
-    find_latest_firmware,
-    is_valid_fw_object,
-)
 from pt_miniscreen.components.info_page import InfoPage
 from pt_miniscreen.core.components.marquee_text import MarqueeText
 
@@ -53,6 +48,16 @@ def system_updates_available():
 
 
 def _has_fw_updates():
+    try:
+        from pt_fw_updater.utils import (
+            default_firmware_folder,
+            find_latest_firmware,
+            is_valid_fw_object,
+        )
+    except ImportError:
+        # probably running pi-topOS lite ...
+        return False
+
     for device_enum in FirmwareDeviceName:
         device_str = device_enum.name
         path_to_fw_folder = default_firmware_folder(device_str)


### PR DESCRIPTION
| Status  | Ticket/Issue |
| :---: | :--: |
| Ready/Hold | [Ticket](https://pi-top.atlassian.net/browse/<ticket-number>) |


#### Main changes
- pi-topOS lite support: don't fail when pt-firmware-updater isn't installed.

#### Screenshots (feature, test output, profiling, dev tools etc)

[insert screenshots here]

#### Other notes (e.g. implementation quirks, edge cases, questions / issues)
-

#### Manual testing tips
-

#### Tag anyone who definitely needs to review or help
-
