### PR TITLE
Fix project page issues

### DIFF
--- a/.github/workflows/deb-build.yml
+++ b/.github/workflows/deb-build.yml
@@ -149,7 +149,7 @@ jobs:
       - name: Upload package build metadata artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.ARTIFACT_PREFIX }}.metadata
+          name: ${{ matrix.distro }}-${{ env.ARTIFACT_PREFIX }}.metadata
           path: |
             ./artifacts/**
             !./artifacts/*.deb

--- a/pt_miniscreen/core/components/stack.py
+++ b/pt_miniscreen/core/components/stack.py
@@ -169,7 +169,12 @@ class Stack(Component):
             return foreground_layer
 
         # crop foreground so it can be offset to the right by x_position
-        crop_boundaries = (0, 0, image.size[0] - x_position, image.size[1])
+        right_bound = image.size[0] - x_position
+        if right_bound < 0:
+            # Newer versions of PIL have a crop method that will raise an error
+            # if the crop boundaries are invalid.
+            right_bound = 0
+        crop_boundaries = (0, 0, right_bound, image.size[1])
         cropped_foreground_layer = foreground_layer.crop(crop_boundaries)
 
         # only foreground exists if one item on the stack

--- a/tests/README.md
+++ b/tests/README.md
@@ -25,6 +25,7 @@ Then, run the tests with:
 ```
 $ docker run \
     --rm \
+    --platform linux/amd64 \
     --volume "$PWD":/src \
     pt-miniscreen-test-runner
 ```
@@ -35,8 +36,10 @@ Override the entrypoint to access the image using `bash`. Then use `pytest --sna
 
 ```
 $ docker run \
+    -ti \
     --rm \
     --volume "$PWD":/src \
+    --platform linux/amd64 \
     --entrypoint bash \
     pitop/pt-miniscreen-test-runner:latest
 ```

--- a/tests/projects_test.py
+++ b/tests/projects_test.py
@@ -34,8 +34,8 @@ def use_example_project(mocker, tmp_path):
                 copytree(f"{config_file_path}/valid", full_path, dirs_exist_ok=True)
 
         mocker.patch(
-            f"pt_miniscreen.pages.root.projects.utils.{project_info_to_mock}.folder",
-            tmp_path,
+            f"pt_miniscreen.pages.root.projects.utils.{project_info_to_mock}.get_folder",
+            lambda: tmp_path,
         )
 
     yield _create_project
@@ -95,8 +95,8 @@ def create_project(mocker, tmp_path):
 
         mocker.patch.object(
             MyProjectsDirectory,
-            "folder",
-            f"{tmp_path}",
+            "get_folder",
+            lambda: f"{tmp_path}",
         )
 
     yield _create_project


### PR DESCRIPTION
| Status  | Ticket/Issue |
| :---: | :--: |
| Ready/Hold | [Ticket](https://pi-top.atlassian.net/browse/SWE-335), [Ticket](https://pi-top.atlassian.net/browse/SWE-336) |


#### Main changes
Issue # 1: When deleting a project on bookworm OS, the app crashes.
Fix: Newer versions of PIL have a crop method that will raise an error if the crop boundaries are invalid. Previously, it didn't perform any checks.

Issue # 2: Sometimes projects in the user folders wouldn't be displayed in the menu.
Fix: This happens because the variable for user home directory was generated when the app started. If the systemd service that runs the app starts when there's no display available yet (which is what we use to determine the username and its home folder), this variable would be set to empty, which is why the projects are not found. Now, the user home directory is determined every time the app needs to access or look up the project folders.

#### Screenshots (feature, test output, profiling, dev tools etc)

[insert screenshots here]

#### Other notes (e.g. implementation quirks, edge cases, questions / issues)
-

#### Manual testing tips
-

#### Tag anyone who definitely needs to review or help
-
